### PR TITLE
public serializer

### DIFF
--- a/Saule/Http/PaginatedAttribute.cs
+++ b/Saule/Http/PaginatedAttribute.cs
@@ -54,18 +54,9 @@ namespace Saule.Http
             var context = actionExecutedContext.Request.Properties[Constants.PaginationContextPropertyName]
                 as PaginationContext;
 
-            var queryable = content?.Value as IQueryable;
-            if (queryable != null)
+            if (content != null)
             {
-                content.Value = new PaginationInterpreter(context).Apply(queryable);
-            }
-            else
-            { // all queryables are enumerable
-                var enumerable = content?.Value as IEnumerable;
-                if (enumerable != null)
-                {
-                    content.Value = new PaginationInterpreter(context).Apply(enumerable);
-                }
+                content.Value = PaginationInterpreter.ApplyPaginationIfApplicable(context, content.Value);
             }
 
             base.OnActionExecuted(actionExecutedContext);

--- a/Saule/JsonApiSerializer.cs
+++ b/Saule/JsonApiSerializer.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Web.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Saule.Queries;
+using Saule.Serialization;
+
+namespace Saule
+{
+    /// <summary>
+    /// Used to manually serialize objects into Json Api.
+    /// </summary>
+    /// <typeparam name="T">The resource type of the objects this serializer can serialize.</typeparam>
+    public sealed class JsonApiSerializer<T> where T : ApiResource, new()
+    {
+        /// <summary>
+        /// Produces the Json Api response that represents the given @object.
+        /// </summary>
+        /// <param name="object">The object to serialize.</param>
+        /// <param name="requestUri">The request uri that prompted the response.</param>
+        /// <returns></returns>
+        public JToken Serialize(object @object, Uri requestUri)
+        {
+            if (requestUri == null) throw new ArgumentNullException(nameof(requestUri));
+
+            var error = SerializeAsError(@object);
+            if (error != null) return error;
+
+            var dataObject = @object;
+            PaginationContext context = null;
+            if (Paginate)
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                context = new PaginationContext(request.GetQueryNameValuePairs(), ItemsPerPage);
+                dataObject = PaginationInterpreter.ApplyPaginationIfApplicable(context, dataObject);
+            }
+
+            var serializer = new ResourceSerializer(dataObject, new T(), requestUri, context);
+            var jsonSerializer = GetJsonSerializer();
+            return serializer.Serialize(jsonSerializer);
+        }
+
+        private JsonSerializer GetJsonSerializer()
+        {
+            var serializer = new JsonSerializer();
+            foreach (var converter in JsonConverters)
+            {
+                serializer.Converters.Add(converter);
+            }
+            return serializer;
+        }
+
+        private static JToken SerializeAsError(object @object)
+        {
+            var exception = @object as Exception;
+            if (exception != null)
+            {
+                var error = new ApiError(exception);
+                return new ErrorSerializer().Serialize(error);
+            }
+
+            var httpError = @object as HttpError;
+            if (httpError != null)
+            {
+                var error = new ApiError(httpError);
+                return new ErrorSerializer().Serialize(error);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Contains converters to influence the serialization process.
+        /// </summary>
+        public ICollection<JsonConverter> JsonConverters { get; } = new JsonConverterCollection();
+
+        /// <summary>
+        /// True if responses should be paginated, otherwise false.
+        /// </summary>
+        public bool Paginate { get; set; } = false;
+
+        /// <summary>
+        /// The number of items per page, if the responses are paginated.
+        /// </summary>
+        public int ItemsPerPage { get; set; } = 10;
+    }
+}

--- a/Saule/Queries/PaginationInterpreter.cs
+++ b/Saule/Queries/PaginationInterpreter.cs
@@ -9,6 +9,27 @@ namespace Saule.Queries
 {
     internal class PaginationInterpreter
     {
+        public static object ApplyPaginationIfApplicable(PaginationContext context, object data)
+        {
+            var queryable = data as IQueryable;
+            var enumerable = data as IEnumerable;
+
+            if (queryable != null)
+            {
+                return new PaginationInterpreter(context).Apply(queryable);
+            }
+            else if (enumerable != null)
+            {
+                // all queryables are enumerable, so this needs to be after
+                // the queryable case
+                return new PaginationInterpreter(context).Apply(enumerable);
+            }
+            else
+            {
+                return data;
+            }
+        }
+
         public PaginationInterpreter(PaginationContext context)
         {
             Context = context;

--- a/Saule/Queries/QueryMethod.cs
+++ b/Saule/Queries/QueryMethod.cs
@@ -42,8 +42,18 @@ namespace Saule.Queries
 
         protected virtual object ApplyToInternal(MethodInfo method, object[] arguments)
         {
-            var typed = method.MakeGenericMethod(arguments[0].GetType().GenericTypeArguments);
+            var typeArguments = GetTypeArguments(arguments[0]);
+            var typed = method.MakeGenericMethod(typeArguments);
             return typed.Invoke(null, arguments);
+        }
+
+        protected static Type[] GetTypeArguments(object o)
+        {
+            var enumerable = o // IQueryable<> extends IEnumerable<>
+                .GetType()
+                .GetInterfaces()
+                .First(i => typeof (IEnumerable<>).IsAssignableFrom(i.GetGenericTypeDefinition()));
+            return enumerable.GetGenericArguments();
         }
 
         private static MethodInfo GetGenericMethodInfo<TReturn>(Expression<Func<object, TReturn>> expression)

--- a/Saule/Saule.csproj
+++ b/Saule/Saule.csproj
@@ -36,6 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Saule.XML</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -61,6 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiResource.cs" />
+    <Compile Include="JsonApiSerializer.cs" />
     <Compile Include="Http\Constants.cs" />
     <Compile Include="Http\PaginatedAttribute.cs" />
     <Compile Include="Http\ReturnsResourceAttribute.cs" />

--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -32,6 +32,7 @@ namespace Saule.Serialization
 
         public JObject Serialize(JsonSerializer serializer)
         {
+            if (_value == null) return SerializeNull(serializer);
             var objectJson = JToken.FromObject(_value, serializer);
             _isCollection = objectJson is JArray;
 
@@ -40,6 +41,15 @@ namespace Saule.Serialization
                 ["data"] = SerializeArrayOrObject(objectJson, SerializeData),
                 ["included"] = _includedSection,
                 ["links"] = CreateTopLevelLinks(_isCollection ? objectJson.Count() : 0)
+            };
+        }
+
+        private JObject SerializeNull(JsonSerializer serializer)
+        {
+            return new JObject
+            {
+                ["data"] = null,
+                ["links"] = CreateTopLevelLinks(0)
             };
         }
 

--- a/Tests/JsonApiSerializerTests.cs
+++ b/Tests/JsonApiSerializerTests.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Web.Http;
+using Newtonsoft.Json.Converters;
+using Saule;
+using Tests.Helpers;
+using Xunit;
+
+namespace Tests
+{
+    public class JsonApiSerializerTests
+    {
+        private static Uri DefaultUrl => new Uri("http://example.com/api/people");
+
+        [Fact(DisplayName = "Does not allow null Uri")]
+        public void HasAContract()
+        {
+            var target = new JsonApiSerializer<PersonResource>();
+            Assert.Throws<ArgumentNullException>(() => target.Serialize(new Person(), null));
+        }
+
+        [Fact(DisplayName = "Serializes Exceptions as errors")]
+        public void WorksOnExceptions()
+        {
+            var target = new JsonApiSerializer<PersonResource>();
+            var result = target.Serialize(new FileNotFoundException(), DefaultUrl);
+
+            Assert.Null(result["data"]);
+            Assert.NotNull(result["errors"]);
+        }
+
+        [Fact(DisplayName = "Serializes HttpErrors as errors")]
+        public void WorksOnHttpErrors()
+        {
+            var target = new JsonApiSerializer<PersonResource>();
+            var result = target.Serialize(new HttpError(), DefaultUrl);
+
+            Assert.Null(result["data"]);
+            Assert.NotNull(result["errors"]);
+        }
+
+        [Fact(DisplayName = "Uses pagination if property set")]
+        public void AppliesPagination()
+        {
+            var target = new JsonApiSerializer<PersonResource>
+            {
+                ItemsPerPage = 5,
+                Paginate = true
+            };
+            var people = GetPeople(20).AsQueryable();
+            var result = target.Serialize(people, DefaultUrl);
+
+            Assert.Equal(5, result["data"].Count());
+            Assert.NotNull(result["links"]["next"]);
+            Assert.NotNull(result["links"]["first"]);
+            Assert.Null(result["links"]["prev"]);
+        }
+
+        [Fact(DisplayName = "Ignores ItemsPerPage if Paginate is disabled")]
+        public void PropertyInteraction()
+        {
+            var target = new JsonApiSerializer<PersonResource>
+            {
+                ItemsPerPage = 2,
+                Paginate = false
+            };
+            var people = GetPeople(5);
+            var result = target.Serialize(people, DefaultUrl);
+
+            Assert.Equal(5, result["data"].Count());
+            Assert.Null(result["links"]["next"]);
+            Assert.Null(result["links"]["first"]);
+            Assert.NotNull(result["links"]["self"]);
+        }
+
+        [Fact(DisplayName = "Uses converters")]
+        public void UsesConverters()
+        {
+            var target = new JsonApiSerializer<TestConvertersResource>();
+            target.JsonConverters.Add(new StringEnumConverter());
+            var result = target.Serialize(new TestConverters(), DefaultUrl);
+
+            Assert.Equal("Second", result["data"]["attributes"].Value<string>("property"));
+        }
+
+        private static IEnumerable<Person> GetPeople(int count)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                yield return new Person(prefill: true, id: (i + 1).ToString());
+            }
+        }
+
+        private class TestConvertersResource : ApiResource
+        {
+            public TestConvertersResource()
+            {
+                Attribute("property");
+            }
+        }
+
+        private class TestConverters
+        {
+            public enum Test
+            {
+                First,
+                Second
+            }
+
+            public Test Property { get; set; } = Test.Second;
+            public string Id { get; set; } = Test.First.ToString();
+        }
+    }
+}

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -92,7 +92,7 @@ namespace Tests.Serialization
             Assert.NotNull(job?["attributes"]);
         }
 
-        [Fact(DisplayName = "Handles null values correctly")]
+        [Fact(DisplayName = "Handles null relationships and attributes correctly")]
         public void HandlesNullValues()
         {
             var person = new Person { Id = "45" };
@@ -129,6 +129,15 @@ namespace Tests.Serialization
 
             Assert.Equal(1, included?.Count);
             Assert.Equal("/people/a/employer/", jobLinks?.Value<Uri>("related").AbsolutePath);
+        }
+
+        [Fact(DisplayName = "Handles null objects correctly")]
+        public void HandlesNullResources()
+        {
+            var target = new ResourceSerializer(null, new PersonResource(), new Uri("http://example.com/people"), null);
+            var result = target.Serialize();
+
+            Assert.Equal(JTokenType.Null, result["data"].Type);
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="ApiResourceTests.cs" />
     <Compile Include="Experiments.cs" />
     <Compile Include="Http\JsonApiMediaTypeFormatterTests.cs" />
+    <Compile Include="JsonApiSerializerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\Person.cs" />
     <Compile Include="Queries\PaginationQueryTests.cs" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 1.1.{build}
+configuration: Release
 assembly_info:
   patch: true
   file: '**\AssemblyInfo.*'


### PR DESCRIPTION
* Move pagination logic out of the attribute
* Add class to handle serialization
* Add tests

Hopefully we can start using `JsonApiSerializer` from within `JsonApiMediaTypeFormatter` soon, but for now it's problematic due to generics.

Closes #17.