### PR TITLE
add recursive exception message to ApiError

### DIFF
--- a/Saule/Serialization/ApiError.cs
+++ b/Saule/Serialization/ApiError.cs
@@ -32,7 +32,7 @@ namespace Saule.Serialization
         private static string GetRecursiveExceptionMessage(HttpError ex)
         {
             var msg = !string.IsNullOrEmpty(ex.ExceptionMessage) ? ex.ExceptionMessage : ex.Message;
-            msg = msg.EnsureEndsWith(".");
+            msg = msg?.EnsureEndsWith(".");
             if (ex.InnerException != null)
             {
                 msg += ' ' + GetRecursiveExceptionMessage(ex.InnerException);

--- a/Saule/Serialization/ApiError.cs
+++ b/Saule/Serialization/ApiError.cs
@@ -32,6 +32,7 @@ namespace Saule.Serialization
         private static string GetRecursiveExceptionMessage(HttpError ex)
         {
             var msg = !string.IsNullOrEmpty(ex.ExceptionMessage) ? ex.ExceptionMessage : ex.Message;
+            msg = msg.EnsureEndsWith(".");
             if (ex.InnerException != null)
             {
                 msg += ' ' + GetRecursiveExceptionMessage(ex.InnerException);

--- a/Saule/Serialization/ApiError.cs
+++ b/Saule/Serialization/ApiError.cs
@@ -16,9 +16,20 @@ namespace Saule.Serialization
 
         internal ApiError(HttpError ex)
         {
-            Title = !string.IsNullOrEmpty(ex.ExceptionMessage) ? ex.ExceptionMessage : ex.Message;
+            Title = GetRecursiveExceptionMessage(ex);
             Detail = ex.StackTrace;
             Code = ex.ExceptionType;
+        }
+
+        private static string GetRecursiveExceptionMessage(HttpError ex)
+        {
+            var msg = !string.IsNullOrEmpty(ex.ExceptionMessage) ? ex.ExceptionMessage : ex.Message;
+            if (ex.InnerException != null)
+            {
+                msg += ' ' + GetRecursiveExceptionMessage(ex.InnerException);
+            }
+
+            return msg;
         }
 
         public string Title { get; }

--- a/Saule/Serialization/ApiError.cs
+++ b/Saule/Serialization/ApiError.cs
@@ -21,6 +21,14 @@ namespace Saule.Serialization
             Code = ex.ExceptionType;
         }
 
+        public string Title { get; }
+
+        public string Detail { get; }
+
+        public string Code { get; }
+
+        public Dictionary<string, string> Links { get; }
+
         private static string GetRecursiveExceptionMessage(HttpError ex)
         {
             var msg = !string.IsNullOrEmpty(ex.ExceptionMessage) ? ex.ExceptionMessage : ex.Message;
@@ -31,13 +39,5 @@ namespace Saule.Serialization
 
             return msg;
         }
-
-        public string Title { get; }
-
-        public string Detail { get; }
-
-        public string Code { get; }
-
-        public Dictionary<string, string> Links { get; }
     }
 }

--- a/Tests/Serialization/ErrorSerializerTests.cs
+++ b/Tests/Serialization/ErrorSerializerTests.cs
@@ -21,12 +21,13 @@ namespace Tests.Serialization
         [Fact(DisplayName = "Serializers HttpError properties")]
         public void SerializesHttpError()
         {
-            var exception = new InvalidOperationException("Some message");
+            var innerException = new ApplicationException("Another message");
+            var exception = new InvalidOperationException("Some message", innerException);
             var httpError = new System.Web.Http.HttpError(exception, true);
 
             var errors = new ErrorSerializer().Serialize(new ApiError(httpError))["errors"][0];
 
-            Assert.Equal(httpError.ExceptionMessage, errors.Value<string>("title"));
+            Assert.Equal("Some message. Another message.", errors.Value<string>("title"));
             Assert.Equal(httpError.ExceptionType, errors.Value<string>("code"));
             Assert.Equal(httpError.StackTrace, errors.Value<string>("detail"));
         }


### PR DESCRIPTION
Meaningful errors were being suppressed when, for example, I accidentally added a duplicate Attribute in my Resource definition.