### PR TITLE
allow generic overriding of filtering lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Version 1.4
 
 - Filtering of attributes through user queries
+  - You can specify the expression that will be executed for specific types, allowing
+    e.g. case-insensitive filtering, and much more.
 - Custom properties to specify the Id of a resource (using `WithId`)
 - New way to set up Saule: use the extension method `ConfigureJsonApi` 
   instead of manually adding the `JsonApiMediaTypeFormatter`.

--- a/Saule/Http/FilterExpressions/CaseInsensitiveStringQueryFilterExpression.cs
+++ b/Saule/Http/FilterExpressions/CaseInsensitiveStringQueryFilterExpression.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Saule.Http.FilterExpressions
+{
+    /// <summary>
+    /// Use to make string comparisons in query filters case insensitive.
+    /// </summary>
+    public sealed class CaseInsensitiveStringQueryFilterExpression : IQueryFilterExpression<string>
+    {
+        /// <summary>
+        /// Returns the filtering expression for the given property.
+        /// </summary>
+        /// <param name="property">The property this queryFilter will be applied to.</param>
+        /// <returns>A <see cref="Func{T1, T2, TResult}"/> that will be used to queryFilter the enumerable.</returns>
+        public Expression<Func<string, string, bool>> GetForProperty(PropertyInfo property)
+        {
+            return (left, right) => left.Equals(right, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Saule/Http/FilterExpressions/DefaultQueryFilterExpression.cs
+++ b/Saule/Http/FilterExpressions/DefaultQueryFilterExpression.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Saule.Http.FilterExpressions
+{
+    /// <summary>
+    /// Use for a simple equality comparison in query filters.
+    /// </summary>
+    /// <typeparam name="T">The type of the property that is being filtered on.</typeparam>
+    [SuppressMessage(
+        "StyleCop.CSharp.DocumentationRules",
+        "SA1649:File name must match first type name",
+        Justification = "This is nicer")]
+    public class DefaultQueryFilterExpression<T> : IQueryFilterExpression<T>
+    {
+        /// <summary>
+        /// Returns the filtering expression for the given property.
+        /// </summary>
+        /// <param name="property">The property this queryFilter will be applied to.</param>
+        /// <returns>A <see cref="Func{T1, T2, TResult}"/> that will be used to queryFilter the enumerable.</returns>
+        public virtual Expression<Func<T, T, bool>> GetForProperty(PropertyInfo property)
+        {
+            var left = Expression.Parameter(typeof(T), "left");
+            var right = Expression.Parameter(typeof(T), "right");
+            return Expression.Lambda<Func<T, T, bool>>(Expression.Equal(left, right), left, right);
+        }
+    }
+}

--- a/Saule/Http/FilterExpressions/LambdaQueryFilterExpression.cs
+++ b/Saule/Http/FilterExpressions/LambdaQueryFilterExpression.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Saule.Http.FilterExpressions
+{
+    /// <summary>
+    /// Use to specify a lambda that will be used in query filtering.
+    /// </summary>
+    /// <typeparam name="T">The type of the property that is being filtered on.</typeparam>
+    [SuppressMessage(
+        "StyleCop.CSharp.DocumentationRules",
+        "SA1649:File name must match first type name",
+        Justification = "This is nicer")]
+    internal class LambdaQueryFilterExpression<T> : IQueryFilterExpression<T>
+    {
+        private readonly Expression<Func<T, T, bool>> _expression;
+
+        public LambdaQueryFilterExpression(Expression<Func<T, T, bool>> expression)
+        {
+            _expression = expression;
+        }
+
+        /// <summary>
+        /// Returns the filtering expression for the given property.
+        /// </summary>
+        /// <param name="property">The property this queryFilter will be applied to.</param>
+        /// <returns>A <see cref="Func{T1, T2, TResult}"/> that will be used to queryFilter the enumerable.</returns>
+        public Expression<Func<T, T, bool>> GetForProperty(PropertyInfo property)
+        {
+            return _expression;
+        }
+    }
+}

--- a/Saule/Http/IQueryFilterExpression.cs
+++ b/Saule/Http/IQueryFilterExpression.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Saule.Http
+{
+    /// <summary>
+    /// Represents an expression that is applied to enumerables when filtering them.
+    /// </summary>
+    /// <typeparam name="T">The type of the property that is being filtered on.</typeparam>
+    [SuppressMessage(
+        "StyleCop.CSharp.DocumentationRules",
+        "SA1649:File name must match first type name",
+        Justification = "This is nicer")]
+    public interface IQueryFilterExpression<T>
+    {
+        /// <summary>
+        /// Returns the filtering expression for the given property.
+        /// </summary>
+        /// <param name="property">The property this filter will be applied to.</param>
+        /// <returns>A <see cref="Func{T1, T2, TResult}"/> that will be used to filter the enumerable.</returns>
+        Expression<Func<T, T, bool>> GetForProperty(PropertyInfo property);
+    }
+}

--- a/Saule/Http/JsonApiConfiguration.cs
+++ b/Saule/Http/JsonApiConfiguration.cs
@@ -18,5 +18,10 @@ namespace Saule.Http
         /// Json converters to manipulate the serialization process.
         /// </summary>
         public ICollection<JsonConverter> JsonConverters { get; } = new List<JsonConverter>();
+
+        /// <summary>
+        /// Determines the expressions that are used to evaluate filter queries on a per-type basis.
+        /// </summary>
+        public QueryFilterExpressionCollection QueryFilterExpressions { get; } = new QueryFilterExpressionCollection();
     }
 }

--- a/Saule/Http/QueryFilterExpressionCollection.cs
+++ b/Saule/Http/QueryFilterExpressionCollection.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Saule.Http.FilterExpressions;
+using Saule.Queries.Filtering;
+
+namespace Saule.Http
+{
+    /// <summary>
+    /// Collection for implementations of <see cref="IQueryFilterExpression{T}"/>.
+    /// </summary>
+    public class QueryFilterExpressionCollection
+    {
+        private readonly Dictionary<Type, GenericDispatcher> _filters = new Dictionary<Type, GenericDispatcher>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryFilterExpressionCollection"/> class.
+        /// </summary>
+        public QueryFilterExpressionCollection()
+        {
+            SetExpression(new DefaultQueryFilterExpression<object>());
+        }
+
+        /// <summary>
+        /// Sets the query filter expression for properties of the specified type.
+        /// </summary>
+        /// <param name="queryFilter">The query filter to use.</param>
+        /// <typeparam name="T">The type of the properties to use this expression for.</typeparam>
+        /// <returns>The query filter expression that is registered.</returns>
+        public IQueryFilterExpression<T> SetExpression<T>(IQueryFilterExpression<T> queryFilter)
+        {
+            var dispatcher = GenericDispatcher.GetFor(queryFilter);
+            var type = typeof(T);
+
+            if (_filters.ContainsKey(type))
+            {
+                _filters[type] = dispatcher;
+            }
+            else
+            {
+                _filters.Add(type, dispatcher);
+            }
+
+            return queryFilter;
+        }
+
+        /// <summary>
+        /// Sets the query filter expression for properties of the specified type.
+        /// </summary>
+        /// <param name="expression">The query filter expression to use.</param>
+        /// <typeparam name="T">The type of the properties to use this expression for.</typeparam>
+        /// <returns>The query filter expression that is registered.</returns>
+        public IQueryFilterExpression<T> SetExpression<T>(Expression<Func<T, T, bool>> expression)
+        {
+            return SetExpression(new LambdaQueryFilterExpression<T>(expression));
+        }
+
+        internal Expression GetQueryFilterExpression(PropertyInfo property)
+        {
+            var type = property.PropertyType;
+
+            var candidates = type.GetInheritanceChain();
+            var bestType = candidates.FirstOrDefault(c => _filters.ContainsKey(c));
+
+            return bestType != null ?
+                _filters[bestType].CallGetFilterExpression(property)
+                : null;
+        }
+
+        private class GenericDispatcher
+        {
+            private readonly object _filter;
+
+            private GenericDispatcher(object filter)
+            {
+                _filter = filter;
+            }
+
+            public static GenericDispatcher GetFor<T>(IQueryFilterExpression<T> queryFilter)
+            {
+                return new GenericDispatcher(queryFilter);
+            }
+
+            public Expression CallGetFilterExpression(PropertyInfo property)
+            {
+                // We can assume this is safe, because the only call path is
+                // compiler guaranteed to have the correct types. We just need
+                // this because we can't have a generic parameter in a dictionary
+                // when we don't know the type until runtime.
+                const string methodName = nameof(IQueryFilterExpression<object>.GetForProperty);
+                var method = _filter.GetType().GetMethod(methodName, new[] { typeof(PropertyInfo) });
+                var expression = method.Invoke(_filter, new object[] { property }) as Expression;
+
+                return MakeCorrectlyTyped(expression, property.PropertyType);
+            }
+
+            private static Expression MakeCorrectlyTyped(Expression expression, Type propertyType)
+            {
+                // expression is of type Expression<Func<propertyType, propertyType, bool>>
+                if (expression.GetType().GenericTypeArguments[0].GenericTypeArguments[0] == propertyType)
+                {
+                    return expression;
+                }
+
+                var typeCorrector = new TypeCorrectingVisitor(propertyType);
+                return typeCorrector.Visit(expression);
+            }
+        }
+    }
+}

--- a/Saule/JsonApiSerializer.cs
+++ b/Saule/JsonApiSerializer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Web.Http;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Saule.Http;
 using Saule.Queries;
 using Saule.Serialization;
 

--- a/Saule/JsonApiSerializerOfT.cs
+++ b/Saule/JsonApiSerializerOfT.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Saule.Http;
 using Saule.Queries;
 using Saule.Queries.Filtering;
 using Saule.Queries.Pagination;
@@ -54,6 +55,11 @@ namespace Saule
         }
 
         /// <summary>
+        /// Used to execute filters specified through query parameters in the request url.
+        /// </summary>
+        public QueryFilterExpressionCollection QueryFilterExpressions { get; } = new QueryFilterExpressionCollection();
+
+        /// <summary>
         /// The number of items per page, if the responses are paginated.
         /// </summary>
         public int ItemsPerPage { get; set; } = 10;
@@ -96,7 +102,7 @@ namespace Saule
             if (AllowQuery)
             {
                 context.Sorting = new SortingContext(keyValuePairs);
-                context.Filtering = new FilteringContext(keyValuePairs);
+                context.Filtering = new FilteringContext(keyValuePairs) { QueryFilters = QueryFilterExpressions };
             }
 
             return context;

--- a/Saule/Properties/AssemblyInfo.cs
+++ b/Saule/Properties/AssemblyInfo.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Saule")]
-[assembly: AssemblyDescription("Json api library for ASP.Net Web API 2")]
+[assembly: AssemblyDescription("Json Api library for ASP.Net Web API 2")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Jouke van der Maas")]
 [assembly: AssemblyProduct("Saule")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Saule/Queries/EnumerableExtensions.cs
+++ b/Saule/Queries/EnumerableExtensions.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Saule.Queries
 {
-    internal static class QueryableExtensions
+    internal static class EnumerableExtensions
     {
         public static object ApplyQuery(this IQueryable queryable, QueryMethod method, params object[] arguments)
         {
@@ -13,6 +14,11 @@ namespace Saule.Queries
         public static object ApplyQuery(this IEnumerable enumerable, QueryMethod method, params object[] arguments)
         {
             return method.ApplyTo(enumerable, arguments);
+        }
+
+        public static IEnumerable<T> ToEnumerable<T>(this T element)
+        {
+            yield return element;
         }
     }
 }

--- a/Saule/Queries/Filtering/FilteringContext.cs
+++ b/Saule/Queries/Filtering/FilteringContext.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Saule.Http;
 
 namespace Saule.Queries.Filtering
 {
@@ -16,5 +17,7 @@ namespace Saule.Queries.Filtering
         }
 
         public IEnumerable<FilteringProperty> Properties { get; }
+
+        public QueryFilterExpressionCollection QueryFilters { get; set; } = new QueryFilterExpressionCollection();
     }
 }

--- a/Saule/Queries/Filtering/FilteringInterpreter.cs
+++ b/Saule/Queries/Filtering/FilteringInterpreter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Linq;
+using Saule.Http;
 
 namespace Saule.Queries.Filtering
 {
@@ -27,7 +28,12 @@ namespace Saule.Queries.Filtering
                 : enumerable;
         }
 
-        private static IEnumerable ApplyProperty(IEnumerable enumerable, FilteringProperty property)
+        private static JsonApiException MissingProperty(string property, Exception ex)
+        {
+            return new JsonApiException($"Attribute '{property.ToDashed()}' not found.", ex);
+        }
+
+        private IEnumerable ApplyProperty(IEnumerable enumerable, FilteringProperty property)
         {
             try
             {
@@ -39,7 +45,7 @@ namespace Saule.Queries.Filtering
 
                 enumerable = enumerable.ApplyQuery(
                     QueryMethod.Where,
-                    Lambda.SelectPropertyValue(elementType, property.Name, property.Value))
+                    Lambda.SelectPropertyValue(elementType, property.Name, property.Value, _context.QueryFilters))
                     as IEnumerable;
 
                 return enumerable;
@@ -50,13 +56,13 @@ namespace Saule.Queries.Filtering
             }
         }
 
-        private static IQueryable ApplyProperty(IQueryable queryable, FilteringProperty property)
+        private IQueryable ApplyProperty(IQueryable queryable, FilteringProperty property)
         {
             try
             {
                 queryable = queryable.ApplyQuery(
                     QueryMethod.Where,
-                    Lambda.SelectPropertyValue(queryable.ElementType, property.Name, property.Value))
+                    Lambda.SelectPropertyValue(queryable.ElementType, property.Name, property.Value, _context.QueryFilters))
                     as IQueryable;
                 return queryable;
             }
@@ -64,11 +70,6 @@ namespace Saule.Queries.Filtering
             {
                 throw MissingProperty(property.Name, ex);
             }
-        }
-
-        private static JsonApiException MissingProperty(string property, Exception ex)
-        {
-            return new JsonApiException($"Attribute '{property.ToDashed()}' not found.", ex);
         }
     }
 }

--- a/Saule/Queries/Filtering/TypeCorrectingVisitor.cs
+++ b/Saule/Queries/Filtering/TypeCorrectingVisitor.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Saule.Queries.Filtering
+{
+    internal class TypeCorrectingVisitor : ExpressionVisitor
+    {
+        private readonly Type _propertyType;
+
+        public TypeCorrectingVisitor(Type propertyType)
+        {
+            _propertyType = propertyType;
+        }
+
+        protected override Expression VisitLambda<T>(Expression<T> node)
+        {
+            var funcType = typeof(Func<,,>)
+                .MakeGenericType(_propertyType, _propertyType, typeof(bool));
+            var expressionFactory = CreateExpressionFactory(funcType);
+
+            return expressionFactory.Invoke(null, new object[]
+            {
+                Visit(node.Body), new[]
+                {
+                    Expression.Parameter(_propertyType, node.Parameters[0].Name),
+                    Expression.Parameter(_propertyType, node.Parameters[1].Name)
+                }
+            }) as Expression;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            return Expression.Parameter(_propertyType, node.Name);
+        }
+
+        protected override Expression VisitUnary(UnaryExpression node)
+        {
+            var item = Visit(node.Operand);
+
+            return Expression.MakeUnary(node.NodeType, item, node.Type, node.Method);
+        }
+
+        protected override Expression VisitBinary(BinaryExpression node)
+        {
+            var left = Visit(node.Left);
+            var right = Visit(node.Right);
+
+            return Expression.MakeBinary(node.NodeType, left, right);
+        }
+
+        private static MethodInfo CreateExpressionFactory(Type funcType)
+        {
+            var expressionFactory = typeof(Expression).GetMethods()
+                .Where(m => m.Name == "Lambda")
+                .Select(m => new
+                {
+                    Method = m,
+                    Params = m.GetParameters(),
+                    Args = m.GetGenericArguments()
+                })
+                .Where(x => x.Params.Length == 2 && x.Args.Length == 1)
+                .Select(x => x.Method)
+                .First()
+                .MakeGenericMethod(funcType);
+            return expressionFactory;
+        }
+    }
+}

--- a/Saule/Queries/Query.cs
+++ b/Saule/Queries/Query.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Linq;
+using Saule.Http;
 using Saule.Queries.Filtering;
 using Saule.Queries.Pagination;
 using Saule.Queries.Sorting;

--- a/Saule/Saule.csproj
+++ b/Saule/Saule.csproj
@@ -45,10 +45,6 @@
       <HintPath>..\packages\Humanizer.1.37.7\lib\portable-win+net40+sl50+wp8+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Humanizer.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="JetBrains.Annotations, Version=6.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.6.1\lib\JetBrains.Annotations.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -75,12 +71,18 @@
     <Compile Include="Http\AllowsQueryAttribute.cs" />
     <Compile Include="Http\HttpConfigExtensions.cs" />
     <Compile Include="Http\JsonApiConfiguration.cs" />
+    <Compile Include="Http\FilterExpressions\CaseInsensitiveStringQueryFilterExpression.cs" />
+    <Compile Include="Http\FilterExpressions\DefaultQueryFilterExpression.cs" />
+    <Compile Include="Http\FilterExpressions\LambdaQueryFilterExpression.cs" />
+    <Compile Include="Http\IQueryFilterExpression.cs" />
     <Compile Include="JsonApiSerializer.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="JsonApiSerializerOfT.cs" />
     <Compile Include="Queries\Filtering\FilteringContext.cs" />
     <Compile Include="Queries\Filtering\FilteringInterpreter.cs" />
     <Compile Include="Queries\Filtering\FilteringProperty.cs" />
+    <Compile Include="Http\QueryFilterExpressionCollection.cs" />
+    <Compile Include="Queries\Filtering\TypeCorrectingVisitor.cs" />
     <Compile Include="Queries\Lambda.cs" />
     <Compile Include="Queries\Query.cs" />
     <Compile Include="Queries\QueryContext.cs" />
@@ -98,7 +100,7 @@
     <Compile Include="RelationshipKind.cs" />
     <Compile Include="Queries\Pagination\PaginationContext.cs" />
     <Compile Include="Queries\Pagination\PaginationInterpreter.cs" />
-    <Compile Include="Queries\QueryableExtensions.cs" />
+    <Compile Include="Queries\EnumerableExtensions.cs" />
     <Compile Include="Queries\QueryMethod.cs" />
     <Compile Include="Queries\Pagination\PaginationQuery.cs" />
     <Compile Include="Serialization\ApiError.cs" />
@@ -122,6 +124,7 @@
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta015\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0-beta015\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets" Condition="Exists('..\packages\StyleCop.Analyzers.1.0.0-beta015\build\StyleCop.Analyzers.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Saule/TypeExtensions.cs
+++ b/Saule/TypeExtensions.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Saule.Queries;
 
 namespace Saule
 {
@@ -13,6 +16,22 @@ namespace Saule
             where T : class
         {
             return Activator.CreateInstance(type) as T;
+        }
+
+        public static IEnumerable<Type> GetInheritanceChain(this Type type)
+        {
+            if (type.BaseType == null)
+            {
+                return type.ToEnumerable()
+                    .Concat(type.GetInterfaces());
+            }
+
+            return type.ToEnumerable()
+                .Concat(type.GetInterfaces())
+                .Concat(type.BaseType.ToEnumerable())
+                .Concat(type.GetInterfaces().SelectMany(GetInheritanceChain))
+                .Concat(type.BaseType.GetInheritanceChain())
+                .Distinct();
         }
     }
 }

--- a/Saule/app.config
+++ b/Saule/app.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <!-- ReSharper disable once MarkupAttributeTypo -->
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>

--- a/Saule/packages.config
+++ b/Saule/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Humanizer" version="1.37.7" targetFramework="net452" />
-  <package id="JetBrains.Annotations" version="6.1" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />

--- a/StyleCop.Analyzers.ruleset
+++ b/StyleCop.Analyzers.ruleset
@@ -74,8 +74,6 @@
     <Rule Id="IDE0003" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1000" Action="Error" />
-    <Rule Id="SA1001" Action="Error" />
     <Rule Id="SA1021" Action="Error" />
     <Rule Id="SA1022" Action="Error" />
     <Rule Id="SA1100" Action="Error" />
@@ -84,6 +82,7 @@
     <Rule Id="SA1110" Action="None" />
     <Rule Id="SA1111" Action="Error" />
     <Rule Id="SA1112" Action="Error" />
+    <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1119" Action="Error" />
     <Rule Id="SA1121" Action="Error" />
     <Rule Id="SA1122" Action="Error" />
@@ -99,7 +98,6 @@
     <Rule Id="SA1311" Action="Error" />
     <Rule Id="SA1400" Action="Error" />
     <Rule Id="SA1401" Action="Error" />
-    <Rule Id="SA1402" Action="Error" />
     <Rule Id="SA1403" Action="Error" />
     <Rule Id="SA1404" Action="Error" />
     <Rule Id="SA1405" Action="Error" />

--- a/Tests/Helpers/ExpressionComparer.cs
+++ b/Tests/Helpers/ExpressionComparer.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Tests.Helpers
+{
+    public class ExpressionComparer : IEqualityComparer<Expression>
+    {
+        public bool Equals(Expression x, Expression y)
+        {
+            return x.Type == y.Type && x.NodeType == y.NodeType && ChildrenEquals(x, y);
+        }
+
+        private bool ChildrenEquals(Expression x, Expression y)
+        {
+            var binaryX = x as BinaryExpression;
+            var binaryY = y as BinaryExpression;
+            if (binaryX != null && binaryY != null)
+                return Equals(binaryX.Left, binaryY.Left)
+                    && Equals(binaryX.Right, binaryY.Right);
+
+            var unaryX = x as UnaryExpression;
+            var unaryY = y as UnaryExpression;
+            if (unaryX != null && unaryY != null)
+                return Equals(unaryX.Operand, unaryY.Operand);
+
+            var funcX = x as LambdaExpression;
+            var funcY = y as LambdaExpression;
+            if (funcX != null && funcY != null)
+                return Equals(funcX.Body, funcY.Body);
+
+            var callX = x as MethodCallExpression;
+            var callY = y as MethodCallExpression;
+            if (callX != null && callY != null)
+                return callX.Arguments.SequenceEqual(callY.Arguments, this)
+                       && callX.Method == callY.Method;
+
+            return true;
+        }
+
+        public int GetHashCode(Expression obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/Tests/Http/QueryFilterExpressionCollectionTests.cs
+++ b/Tests/Http/QueryFilterExpressionCollectionTests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Saule.Http;
+using Tests.Helpers;
+using Xunit;
+
+namespace Tests.Http
+{
+    public class QueryFilterExpressionCollectionTests
+    {
+        [Fact(DisplayName = "Works with method calls in the expression")]
+        public void WorksWithMethodCalls()
+        {
+            var collection = new QueryFilterExpressionCollection();
+            collection.SetExpression<Child>((x, y) => x.StringEquals(y.ToString()));
+            var property = CreatePropertyInfo<Child>();
+
+            var result = collection.GetQueryFilterExpression(property);
+
+            AssertExpressionEqual<Child>((x, y) => x.StringEquals(y.ToString()), result);
+        }
+
+        [Fact(DisplayName = "Setting a new expression overwrites the previous")]
+        public void SetOverridesOldValue()
+        {
+            var collection = new QueryFilterExpressionCollection();
+            var property = CreatePropertyInfo<Child>();
+
+            collection.SetExpression<Child>((x, y) => x.GetHashCode() == y.GetHashCode());
+            var result = collection.GetQueryFilterExpression(property);
+            AssertExpressionEqual<Child>((x, y) => x.GetHashCode() == y.GetHashCode(), result);
+
+            collection.SetExpression<Child>((x, y) => x != y);
+            result = collection.GetQueryFilterExpression(property);
+            AssertExpressionEqual<Child>((x, y) => x != y, result);
+        }
+
+        [Fact(DisplayName = "Has default expression for any unset type")]
+        public void HasDefaultExpression()
+        {
+            var collection = new QueryFilterExpressionCollection();
+            var childProperty = CreatePropertyInfo<Child>();
+            var parentProperty = CreatePropertyInfo<Parent>();
+
+            var childResult = collection.GetQueryFilterExpression(childProperty);
+            var parentResult = collection.GetQueryFilterExpression(parentProperty);
+
+            AssertExpressionEqual<Child>((x, y) => x == y, childResult);
+            AssertExpressionEqual<Parent>((x, y) => x == y, parentResult);
+        }
+
+        [Fact(DisplayName = "Finds the real type before the base type")]
+        public void FindsRealTypeFirst()
+        {
+            var collection = new QueryFilterExpressionCollection();
+            collection.SetExpression<Parent>((x, y) => x != y);
+            collection.SetExpression<Child>((x, y) => x.GetHashCode() == y.GetHashCode());
+            var childProperty = CreatePropertyInfo<Child>();
+            var parentProperty = CreatePropertyInfo<Parent>();
+
+            var childResult = collection.GetQueryFilterExpression(childProperty);
+            var parentResult = collection.GetQueryFilterExpression(parentProperty);
+
+            AssertExpressionEqual<Child>((x, y) => x.GetHashCode() == y.GetHashCode(), childResult);
+            AssertExpressionEqual<Parent>((x, y) => x != y, parentResult);
+        }
+
+        [Fact(DisplayName = "Finds the expression set for the type")]
+        public void FindsCorrectExpression()
+        {
+            var collection = new QueryFilterExpressionCollection();
+            collection.SetExpression<Child>((x, y) => x != y);
+            var property = CreatePropertyInfo<Child>();
+
+            var result = collection.GetQueryFilterExpression(property);
+
+            AssertExpressionEqual<Child>((x, y) => x != y, result);
+        }
+
+        [Fact(DisplayName = "Finds the expression set for base type")]
+        public void FindsCorrectExpressionWithInheritance()
+        {
+            var collection = new QueryFilterExpressionCollection();
+            collection.SetExpression<Parent>((x, y) => x != y);
+            var property = CreatePropertyInfo<Child>();
+
+            var result = collection.GetQueryFilterExpression(property);
+
+            AssertExpressionEqual<Child>((x, y) => x != y, result);
+        }
+
+        private static void AssertExpressionEqual<T>(Expression<Func<T, T, bool>> expected, Expression actual)
+        {
+            // The actual expression could be of a different type, if something
+            // is broken (the collection is supposed to change the types internally)
+            Assert.IsType(typeof(Expression<Func<T, T, bool>>), actual);
+
+            var actualFunc = actual as Expression<Func<T, T, bool>>;
+
+            Assert.Equal(expected, actualFunc, new ExpressionComparer());
+        }
+
+        private static PropertyInfo CreatePropertyInfo<T>() where T : new()
+        {
+            var type = new
+            {
+                Property = new T()
+            };
+
+            return type.GetType().GetProperty("Property");
+        }
+
+        private class Parent
+        {
+            public bool StringEquals(string other)
+            {
+                return ToString() == other;
+            }
+        }
+        private class Child : Parent { }
+    }
+}
+

--- a/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
+++ b/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
@@ -426,5 +426,28 @@ namespace Tests.Integration
                     error["detail"].Value<string>());
             }
         }
+
+        [Fact(DisplayName = "Uses user specified query filter expression for filtering")]
+        public async Task UsesQueryFilterExpression()
+        {
+            var config = new JsonApiConfiguration();
+            config.QueryFilterExpressions.SetExpression<string>((left, right) => left != right);
+
+            using (var server = new NewSetupJsonApiServer(config))
+            {
+                var client = server.GetClient();
+                var result = await client.GetJsonResponseAsync("/query/people?filter[last-name]=Russel");
+                _output.WriteLine(result.ToString());
+
+                var names = ((JArray)result["data"])
+                    .Select(p => p["attributes"]["last-name"].Value<string>())
+                    .ToList();
+
+                var filtered = names.Where(a => a != "Russel").ToList();
+
+                Assert.Equal(filtered.Count, names.Count);
+            }
+
+        }
     }
 }

--- a/Tests/JsonApiSerializerTests.cs
+++ b/Tests/JsonApiSerializerTests.cs
@@ -23,6 +23,26 @@ namespace Tests
             _output = output;
         }
 
+        [Fact(DisplayName = "Uses query filter expressions if specified")]
+        public void UsesQueryFilterExpressions()
+        {
+            var target = new JsonApiSerializer<CompanyResource>
+            {
+                AllowQuery = true
+            };
+            target.QueryFilterExpressions.SetExpression<LocationType>((left, right) => left != right);
+
+            var companies = Get.Companies(100).ToList().AsQueryable();
+            var result = target.Serialize(companies, new Uri(DefaultUrl, "?filter[location]=1"));
+            _output.WriteLine(result.ToString());
+
+            var filtered = ((JArray)result["data"]).ToList();
+
+            var expected = companies.Where(x => x.Location != LocationType.National).ToList();
+
+            Assert.Equal(expected.Count, filtered.Count);
+        }
+
         [Fact(DisplayName = "Applies filtering if allowed")]
         public void AppliesFilters()
         {

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -110,7 +110,9 @@
     <Compile Include="Helpers\HttpClientExtensions.cs" />
     <Compile Include="Helpers\NewSetupJsonApiServer.cs" />
     <Compile Include="Http\AttributeTests.cs" />
+    <Compile Include="Helpers\ExpressionComparer.cs" />
     <Compile Include="Http\JsonApiMediaTypeFormatterTests.cs" />
+    <Compile Include="Http\QueryFilterExpressionCollectionTests.cs" />
     <Compile Include="Integration\JsonApiMediaTypeFormatterTests.cs" />
     <Compile Include="Models\Company.cs" />
     <Compile Include="Models\CompanyResource.cs" />


### PR DESCRIPTION
When this pr is done, a user should be able to manipulate the filter that is used internally, e.g.:

```csharp
MyFilters.Set<string>((left, right) => left.ToUpperInvariant() == right.ToUpperInvariant());
```

for case-insensitive filtering on strings, or

```csharp
MyFilters.Set<string>((left, right) => left.Contains(right));
```

for substring search. At runtime, these will be substituted for the real values, e.g.:

```csharp
returnedQueryable.Where((i) => i.SomeProperty.Contains(someFilter));
```

Note that all filters derive from `IQueryFilterExpression<T>`, which also has access to the `PropertyInfo` of the property that is being filtered on. This way, you could theoretically implement different filtering for specific properties, while doing some default for others. Saule will likely leave it up to users to implement this (reading e.g. attributes is trivial with this API).

Todo:
- [x] design user api
- [x] add support in `JsonApiSerializer<T>` and `JsonApiMediaTypeFormatter`
- [x] add lots of tests
  - [x] unit tests for internals
  - [x] integration tests for `JsonApiSerializer<T>`
  - [x] integration tests for `JsonApiMediaTypeFormatter`
- [ ] docs
- [x] changelog