### PR TITLE
Find url namespace by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,5 @@
   (requires the new setup)
 - [**BUGFIX**] Saule now supports recursive object graphs
 - [**BUGFIX**] Saule can now be installed in .NET 4.5 projects
+- [**BUGFIX**] Iconsistency between top-level `self` link and generated urls. If you don't specify an
+  url path builder, the path namespace is now automatically guessed for you.

--- a/Saule/Http/JsonApiConfiguration.cs
+++ b/Saule/Http/JsonApiConfiguration.cs
@@ -12,7 +12,7 @@ namespace Saule.Http
         /// <summary>
         /// Determines how to generate urls for links.
         /// </summary>
-        public IUrlPathBuilder UrlPathBuilder { get; set; } = new DefaultUrlPathBuilder();
+        public IUrlPathBuilder UrlPathBuilder { get; set; } = null;
 
         /// <summary>
         /// Json converters to manipulate the serialization process.

--- a/Saule/Serialization/DefaultUrlPathBuilder.cs
+++ b/Saule/Serialization/DefaultUrlPathBuilder.cs
@@ -1,4 +1,9 @@
-﻿namespace Saule.Serialization
+﻿using System;
+using System.Linq;
+using Humanizer;
+using Saule.Queries;
+
+namespace Saule.Serialization
 {
     /// <summary>
     /// Used to build url paths.
@@ -22,6 +27,14 @@
         public DefaultUrlPathBuilder(string prefix)
         {
             _prefix = prefix;
+        }
+
+        internal DefaultUrlPathBuilder(string template, ApiResource resource)
+        {
+            var parts = template.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            var start = parts.TakeWhile(p => !p.StartsWith("{")).ToList();
+
+            _prefix = '/'.TrimJoin(start.Take(start.Count - 1).ToArray());
         }
 
         /// <summary>

--- a/Tests/Controllers/BrokenController.cs
+++ b/Tests/Controllers/BrokenController.cs
@@ -7,7 +7,7 @@ namespace Tests.Controllers
     public class BrokenController : ApiController
     {
         [HttpGet]
-        [Route("broken/{id}")]
+        [Route("api/broken/{id}")]
         public Person GetPerson(string id)
         {
             return Get.Person(id);

--- a/Tests/Controllers/CompaniesController.cs
+++ b/Tests/Controllers/CompaniesController.cs
@@ -10,7 +10,7 @@ namespace Tests.Controllers
     public class CompaniesController : ApiController
     {
         [HttpGet]
-        [Route("companies/{id}")]
+        [Route("api/companies/{id}")]
         public Company GetCompany(string id)
         {
             var company = Get.Company(id);
@@ -21,7 +21,7 @@ namespace Tests.Controllers
 
         [HttpGet]
         [Paginated(PerPage = 12)]
-        [Route("companies")]
+        [Route("api/companies")]
         public IEnumerable<Company> GetCompanies()
         {
             return Get.Companies(100);

--- a/Tests/Controllers/PeopleController.cs
+++ b/Tests/Controllers/PeopleController.cs
@@ -11,7 +11,7 @@ namespace Tests.Controllers
     public class PeopleController : ApiController
     {
         [HttpGet]
-        [Route("people/{id}")]
+        [Route("api/people/{id}")]
         public Person GetPerson(string id)
         {
             return Get.Person(id);
@@ -19,7 +19,7 @@ namespace Tests.Controllers
 
         [HttpGet]
         [AllowsQuery]
-        [Route("query/people")]
+        [Route("api/query/people")]
         public IEnumerable<Person> QueryPeople()
         {
             return GetPeople();
@@ -28,7 +28,7 @@ namespace Tests.Controllers
         [HttpGet]
         [AllowsQuery]
         [Paginated]
-        [Route("query/paginate/people")]
+        [Route("api/query/paginate/people")]
         public IEnumerable<Person> QueryAndPaginatePeople()
         {
             return GetPeopleNotRandom();
@@ -37,14 +37,14 @@ namespace Tests.Controllers
         [HttpGet]
         [Paginated]
         [AllowsQuery]
-        [Route("paginate/query/people")]
+        [Route("api/paginate/query/people")]
         public IEnumerable<Person> PaginateAndQueryPeople()
         {
             return GetPeopleNotRandom();
         }
 
         [HttpPost]
-        [Route("people/{id}")]
+        [Route("api/people/{id}")]
         public Person PostPerson(string id, Person person)
         {
             person.Identifier = id;
@@ -52,7 +52,7 @@ namespace Tests.Controllers
         }
 
         [HttpGet]
-        [Route("people")]
+        [Route("api/people")]
         public IEnumerable<Person> GetPeople()
         {
             return Get.People(100);

--- a/Tests/Helpers/Paths.cs
+++ b/Tests/Helpers/Paths.cs
@@ -2,8 +2,8 @@
 {
     public static class Paths
     {
-        public const string SingleResource = "people/123/";
-        public const string ResourceCollection = "people/";
-        public const string NonExistingPath = "wrong/";
+        public const string SingleResource = "api/people/123/";
+        public const string ResourceCollection = "api/people/";
+        public const string NonExistingPath = "api/wrong/";
     }
 }


### PR DESCRIPTION
This makes the 'prefix' parameter unnecessary for `DefaultUrlPathBuilder` in 90% of cases. Fixes #71.

This works by assuming that urls take the form `/prefix/resource/{id}/` where `{id}` is optional. If that is not true for you, you should still use 'prefix' or implement `IUrlPathBuilder`.