### PR TITLE
don't require attribute for empty responses

### DIFF
--- a/Saule/Http/PreprocessingDelegatingHandler.cs
+++ b/Saule/Http/PreprocessingDelegatingHandler.cs
@@ -35,7 +35,7 @@ namespace Saule.Http
             {
                 resource = (ApiResource)request.Properties[Constants.RequestPropertyName];
             }
-            else if (!(content is HttpError))
+            else if (content != null && !(content is HttpError))
             {
                 content = new JsonApiException(
                     ErrorType.Server,

--- a/Tests/Controllers/CompaniesController.cs
+++ b/Tests/Controllers/CompaniesController.cs
@@ -6,12 +6,12 @@ using Tests.Models;
 
 namespace Tests.Controllers
 {
-    [ReturnsResource(typeof(CompanyResource))]
     [RoutePrefix("api")]
     public class CompaniesController : ApiController
     {
         [HttpGet]
         [Route("companies/{id}")]
+        [ReturnsResource(typeof(CompanyResource))]
         public Company GetCompany(string id)
         {
             var company = Get.Company(id);
@@ -20,9 +20,18 @@ namespace Tests.Controllers
             return company;
         }
 
+        // note: no ReturnsResource!
+        [HttpDelete]
+        [Route("companies/{id}")]
+        public void DeleteCompany(string id)
+        {
+            
+        }
+
         [HttpGet]
         [Paginated(PerPage = 12)]
         [Route("companies")]
+        [ReturnsResource(typeof(CompanyResource))]
         public IEnumerable<Company> GetCompanies()
         {
             return Get.Companies(100);

--- a/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
+++ b/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
@@ -469,6 +469,18 @@ namespace Tests.Integration
             }
         }
 
+        [Fact(DisplayName = "Works with delete/no content")]
+        public async Task WorksForNoContent()
+        {
+            using (var server = new NewSetupJsonApiServer())
+            {
+                var client = server.GetClient();
+                var result = await client.DeleteAsync("/api/companies/123");
+
+                Assert.Equal(HttpStatusCode.NoContent, result.StatusCode);
+            }
+        }
+
         [Fact(DisplayName = "Uses user specified query filter expression for filtering")]
         public async Task UsesQueryFilterExpression()
         {


### PR DESCRIPTION
This allows you to create e.g. a delete without having to specify an unused `ReturnsResourceAttribute`.