### PR TITLE
use Guids as id's

### DIFF
--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -183,7 +183,7 @@ namespace Saule.Serialization
                 data["links"] = AddUrl(
                     new JObject(),
                     "self",
-                    _urlBuilder.BuildCanonicalPath(_resource, EnsureHasId(properties, _resource).Value<string>()));
+                    _urlBuilder.BuildCanonicalPath(_resource, (string)EnsureHasId(properties, _resource)));
             }
 
             return data;
@@ -221,7 +221,7 @@ namespace Saule.Serialization
             var relToken = GetMinimumRelationship(
                 objId.ToString(),
                 relationship,
-                relationshipProperties != null ? GetId(relationshipProperties, relationship.RelatedResource).Value<string>() : null);
+                relationshipProperties != null ? (string)GetId(relationshipProperties, relationship.RelatedResource) : null);
             if (relationshipValues == null)
             {
                 return relToken;
@@ -247,7 +247,7 @@ namespace Saule.Serialization
                     var includedData = values.DeepClone();
                     var url = _urlBuilder.BuildCanonicalPath(
                         relationship.RelatedResource,
-                        EnsureHasId(props, relationship.RelatedResource).Value<string>());
+                        (string)EnsureHasId(props, relationship.RelatedResource));
 
                     includedData["attributes"] = SerializeAttributes(props, relationship.RelatedResource);
                     includedData["links"] = AddUrl(new JObject(), "self", url);
@@ -276,8 +276,8 @@ namespace Saule.Serialization
         private bool IsResourceIncluded(JToken includedData)
         {
             return _includedSection.Any(t =>
-                t.Value<string>("type") == includedData.Value<string>("type") &&
-                t.Value<string>("id") == includedData.Value<string>("id"));
+                (string)t["type"] == (string)includedData["type"] &&
+                (string)t["id"] == (string)includedData["id"]);
         }
 
         private JObject AddUrl(JObject @object, string name, string path)

--- a/Tests/Models/GuidAsRelation.cs
+++ b/Tests/Models/GuidAsRelation.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace Tests.Models
+{
+    internal class GuidAsRelation
+    {
+        public GuidAsRelation(string id = "938")
+        {
+            Id = id;
+            Relation = new GuidAsId();
+            Relations = new [] { new GuidAsId(), new GuidAsId() };
+        }
+
+        public string Id { get; set; }
+
+        public GuidAsId Relation { get; set; }
+
+        public IEnumerable<GuidAsId> Relations {get; set;}
+    }
+}

--- a/Tests/Models/PersonWithGuidAsRelationsResource.cs
+++ b/Tests/Models/PersonWithGuidAsRelationsResource.cs
@@ -1,0 +1,16 @@
+﻿using Saule;
+
+namespace Tests.Models
+{
+    public class PersonWithGuidAsRelationsResource : ApiResource
+    {
+        public PersonWithGuidAsRelationsResource()
+        {
+            WithId(nameof(GuidAsRelation.Id));
+
+            BelongsTo<PersonWithDefaultIdResource>(nameof(GuidAsRelation.Relation));
+
+            HasMany<PersonWithDefaultIdResource>(nameof(GuidAsRelation.Relations));
+        }
+    }
+}

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -315,6 +315,33 @@ namespace Tests.Serialization
             Assert.Equal(guid.Id, guidResult["data"].Value<Guid>("id"));
         }
 
+        [Fact(DisplayName = "Supports Guids for ids in collections")]
+        public void SupportsGuidIdsInCollections()
+        {
+            var guids = new [] { new GuidAsId(), new GuidAsId() };
+            var serializer = new ResourceSerializer(guids, new PersonWithDefaultIdResource(),
+                GetUri(id: "123"), DefaultPathBuilder, null);
+
+            var guidsResult = serializer.Serialize();
+            _output.WriteLine(guidsResult.ToString());
+
+            Assert.NotEmpty(guidsResult["data"]);
+        }
+
+        [Fact(DisplayName = "Supports Guids for id in relations")]
+        public void SupportsGuidsAsRelations()
+        {
+            var relatedToGuidId = new GuidAsRelation();
+            var serializer = new ResourceSerializer( relatedToGuidId, new PersonWithGuidAsRelationsResource(),
+                GetUri(id: "123"), DefaultPathBuilder, null);
+
+            var result = serializer.Serialize();
+            _output.WriteLine(result.ToString());
+
+            Assert.NotNull(result["data"]["relationships"]["relation"]);
+            Assert.NotNull(result["data"]["relationships"]["relations"]);
+        }
+
         [Fact(DisplayName = "Does not serialize attributes that are not found")]
         public void SerializeOnlyWhatYouHave()
         {

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -118,9 +118,11 @@
     <Compile Include="Models\CompanyResource.cs" />
     <Compile Include="Models\CompanyWithDifferentId.cs" />
     <Compile Include="Models\CompanyWithDifferentIdResource.cs" />
+    <Compile Include="Models\GuidAsRelation.cs" />
     <Compile Include="Models\GuidAsId.cs" />
     <Compile Include="Helpers\ObsoleteSetupJsonApiServer.cs" />
     <Compile Include="Helpers\Paths.cs" />
+    <Compile Include="Models\PersonWithGuidAsRelationsResource.cs" />
     <Compile Include="Models\PersonResource.cs" />
     <Compile Include="Models\PersonWithDefaultIdResource.cs" />
     <Compile Include="Models\PersonWithDifferentId.cs" />


### PR DESCRIPTION
The use of Guids as id's leads to the following types of exception when id's are converted to strings:
```
{System.InvalidCastException: Object must implement IConvertible.
   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
   at Newtonsoft.Json.Linq.Extensions.Convert[T,U](T token)
   at Newtonsoft.Json.Linq.Extensions.Value[T,U](IEnumerable`1 value)
   at Newtonsoft.Json.Linq.Extensions.Value[U](IEnumerable`1 value)
   at Saule.Serialization.ResourceSerializer.<>c__DisplayClass23_0.<GetRelationshipData>b__0(IDictionary`2 props)
   at Saule.Serialization.ResourceSerializer.SerializeArrayOrObject(JToken token, Func`2 serializeObj)
   at Saule.Serialization.ResourceSerializer.GetRelationshipData(ResourceRelationship relationship, JToken relationshipValues)
   at Saule.Serialization.ResourceSerializer.SerializeRelationship(ResourceRelationship relationship, IDictionary`2 properties)
   at Saule.Serialization.ResourceSerializer.SerializeRelationships(IDictionary`2 properties)
   at Saule.Serialization.ResourceSerializer.SerializeData(IDictionary`2 properties)
   at Saule.Serialization.ResourceSerializer.SerializeArrayOrObject(JToken token, Func`2 serializeObj)
   at Saule.Serialization.ResourceSerializer.Serialize(JsonSerializer serializer)
   at Saule.JsonApiSerializer.Serialize(PreprocessResult result)
   at Saule.JsonApiSerializer`1.Serialize(Object object, Uri requestUri)
   at ...
```

This happens with:
- collections of objects with Guid-ids
- single objects with `belongsTo`-relations to objects with Guid-ids
- single objects with `hasMany `-relations to objects with Guid-ids.

Unit tests for these cases have been added.

These exceptions can be solved by replacing occurences of `JToken.Value<string>()` by cast operators that are explicitly defined for `JToken`'s (see [here](https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/Linq/JToken.cs#L1223)). This cast operator throws exceptions if the `JToken` does not contain the proper datatypes as defined in [this list](https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/Linq/JToken.cs#L74), which seems to contain every type that might be used as an index. Finally it uses `Convert.ToString(...)` which first tries to convert through `IConvertible`, just like the `JToken.Value<string>()`-conversion method does, so this change should not break any existing working behaviour.