### PR TITLE
allow manual serialization

### DIFF
--- a/Saule/Http/JsonApiMediaTypeFormatter.cs
+++ b/Saule/Http/JsonApiMediaTypeFormatter.cs
@@ -110,6 +110,13 @@ namespace Saule.Http
                 preprocessed = PreprocessingDelegatingHandler.PreprocessRequest(value, _request, _config);
             }
 
+            var preSerializedJson = preprocessed.ResourceSerializer.Value as JObject;
+            if (preSerializedJson != null)
+            {
+                await WriteJsonToStream(preSerializedJson, writeStream);
+                return;
+            }
+
             var json = JsonApiSerializer.Serialize(preprocessed);
             await WriteJsonToStream(json, writeStream);
         }

--- a/Saule/Http/PreprocessingDelegatingHandler.cs
+++ b/Saule/Http/PreprocessingDelegatingHandler.cs
@@ -62,6 +62,11 @@ namespace Saule.Http
 
             var value = result.Content as ObjectContent;
 
+            if (value?.Value is Newtonsoft.Json.Linq.JObject)
+            {
+                return result;
+            }
+
             var content = PreprocessRequest(value?.Value, request, _config);
 
             if (content.ErrorContent != null)

--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -17,6 +17,8 @@ namespace Saule.Serialization
         private readonly IUrlPathBuilder _urlBuilder;
         private bool _isCollection;
 
+        internal object Value => _value;
+
         public ResourceSerializer(
             object value,
             ApiResource type,


### PR DESCRIPTION
I was trying to manually serialize, because I am writing a general CRUD controller.


basically, this is what I was trying to do:

```csharp
    public class DefaultCrudController<TDbType, TResource>: ApplicationController where TResource : Saule.ApiResource, new()
    {

        [HttpGet]
        [ReturnsResource(typeof(ApplicationResource))]
        public JToken Index()
        {
            var collection = CollectionFromUser();
            return RenderResource(collection);
         }

        [HttpGet]
        public JToken Show(string id)
        {
            var resource = Resource(id);
            return RenderResource(resource);
        }

        [HttpPut]
        public JToken Update(string id, [FromBody] JObject bodyParams)
        {
            var resource = Resource(id);
            resource.Update(bodyParams);
            return RenderResource(resource);
        }

        [HttpPost]
        public JToken Create([FromBody] JObject bodyParams)
        {
            var collection = CollectionFromUser();
            var obj = collection.Create(bodyParams);

            return RenderResource(obj);
        }

        [HttpDelete]
        public JToken Destroy(object id)
        {
            var resource = Resource(id);

            resource.Destroy();
            return RenderResponseForJson();
        }


        #region Helpers

        [NonAction]
        protected dynamic CollectionFromUser()
        {
            var serializer = new JsonApiSerializer<TResource>();
            var methodName = typeof(TDbType).Name.Pluralize(inputIsKnownToBeSingular: false);
            var collection = TypedCurrentUser.Send(methodName);
            return collection;
        }


        [NonAction]
        protected dynamic Resource(object id)
        {
            var obj = CollectionFromUser().Find(id);
            return obj;
        }

        [NonAction]
        protected JToken RenderResponseForJson(JToken json = null)
        {
            return null;
        }

        [NonAction]
        protected JToken RenderResource(dynamic obj)
        {
            var serializer = new JsonApiSerializer<TResource>();
            JToken json = serializer.Serialize(obj, Request.RequestUri);
            return json;
        }

        #endregion

    }

```

it's still a work in progress, but what was tripping me up was in here:

```csharp

        [NonAction]
        protected JToken RenderResource(dynamic obj)
        {
            var serializer = new JsonApiSerializer<TResource>();
            JToken json = serializer.Serialize(obj, Request.RequestUri);
            return json;
        }

```

it looks like Saule, no matter what, always tries to take the result of an action and tries to serialize it. 
That's great. But Since I can't use GenericTypes on `ReturnResource`, I had to come up with a different way to do this. 

