### PR TITLE
Serialize recursively placing all nested objects in the 'included' array

### DIFF
--- a/Tests/Models/Recursion.cs
+++ b/Tests/Models/Recursion.cs
@@ -4,32 +4,64 @@ namespace Tests.Models
 {
     internal static class Recursion
     {
-        public class Resource : ApiResource
+        public class FirstModelResource : ApiResource
         {
-            public Resource()
+            public FirstModelResource()
             {
-                BelongsTo<Second>("Model");
+                BelongsTo<SecondModelResource>("Child");
             }
+        }
 
-            private class Second : ApiResource
+        public class SecondModelResource : ApiResource
+        {
+            public SecondModelResource()
             {
-                public Second()
-                {
-                    BelongsTo<Resource>("Model");
-                }
+                BelongsTo<FirstModelResource>("Parent");
+                BelongsTo<ThirdModelResource>("Child");
+            }
+        }
+
+        public class ThirdModelResource : ApiResource
+        {
+            public ThirdModelResource()
+            {
+                BelongsTo<SecondModelResource>("Parent");
+                BelongsTo<FourthModelResource>("Child");
+            }
+        }
+
+        public class FourthModelResource : ApiResource
+        {
+            public FourthModelResource()
+            {
+                BelongsTo<ThirdModelResource>("Parent");
             }
         }
 
         public class FirstModel
         {
-            public string Id => "123";
-            public SecondModel Model { get; set; }
+            public string Id = "1";
+            public SecondModel Child { get; set; }
         }
 
         public class SecondModel
         {
-            public string Id => "456";
-            public FirstModel Model { get; set; }
+            public string Id = "2";
+            public FirstModel Parent { get; set; }
+            public ThirdModel Child { get; set; }
+        }
+
+        public class ThirdModel
+        {
+            public string Id = "3";
+            public SecondModel Parent { get; set; }
+            public FourthModel Child { get; set; }
+        }
+
+        public class FourthModel
+        {
+            public string Id = "4";
+            public ThirdModel Parent { get; set; }
         }
     }
 }

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -31,11 +31,17 @@ namespace Tests.Serialization
         {
             var firstModel = new Recursion.FirstModel();
             var secondModel = new Recursion.SecondModel();
-            firstModel.Model = secondModel;
-            secondModel.Model = firstModel;
+            var thirdModel = new Recursion.ThirdModel();
+            var fourthModel = new Recursion.FourthModel();
+            firstModel.Child = secondModel;
+            secondModel.Parent = firstModel;
+            secondModel.Child = thirdModel;
+            thirdModel.Parent = secondModel;
+            thirdModel.Child = fourthModel;
+            fourthModel.Parent = thirdModel;
 
-            var target = new ResourceSerializer(firstModel, new Recursion.Resource(), 
-                GetUri(id: "123"), DefaultPathBuilder, null);
+            var target = new ResourceSerializer(firstModel, new Recursion.FirstModelResource(), 
+                GetUri(id: firstModel.Id), DefaultPathBuilder, null);
 
             var result = target.Serialize();
             _output.WriteLine(result.ToString());
@@ -43,6 +49,7 @@ namespace Tests.Serialization
             var id = result["data"].Value<string>("id");
 
             Assert.Equal(firstModel.Id, id);
+            Assert.Equal(3, (result["included"] as JArray).Count);
         }
 
         [Fact(DisplayName = "Uses a property called 'Id' when none is specified for Ids")]


### PR DESCRIPTION
Added functionality that recursively serializes a model, placing all nested objects in the `included` array. This conforms to the JSON API spec, which states:

http://jsonapi.org/format/#document-top-level

A document MAY contain any of these top-level members:

- jsonapi: an object describing the server’s implementation
- links: a links object related to the primary data.
- **included: an array of resource objects that are related to the primary data and/or each other (“included resources”).**