### PR TITLE
Fix for #111 and #116

### DIFF
--- a/Saule/Http/PreprocessingDelegatingHandler.cs
+++ b/Saule/Http/PreprocessingDelegatingHandler.cs
@@ -11,6 +11,8 @@ using Saule.Serialization;
 
 namespace Saule.Http
 {
+    using System.Linq;
+
     /// <summary>
     /// Processes JSON API responses to enable filtering, pagination and sorting.
     /// </summary>
@@ -61,10 +63,12 @@ namespace Saule.Http
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var result = await base.SendAsync(request, cancellationToken);
+            var hasMediaType = request.Headers.Accept.Any(x => x.MediaType == Constants.MediaType);
 
             var statusCode = (int)result.StatusCode;
-            if (statusCode >= 400 && statusCode < 500)
-            { // probably malformed request or not found
+            if (!hasMediaType || (statusCode >= 400 && statusCode < 500))
+            {
+                // probably malformed request or not found
                 return result;
             }
 

--- a/Tests/Controllers/StaticController.cs
+++ b/Tests/Controllers/StaticController.cs
@@ -1,0 +1,15 @@
+﻿namespace Tests.Controllers
+{
+    using System.Net;
+    using System.Web.Http;
+   
+    [RoutePrefix("static")]
+    public class StaticController : ApiController
+    {
+        [Route("text")]
+        public IHttpActionResult GetStaticFile()
+        {
+            return this.Content(HttpStatusCode.OK, "This is static content.");
+        }
+    }
+}

--- a/Tests/Controllers/StaticController.cs
+++ b/Tests/Controllers/StaticController.cs
@@ -6,6 +6,7 @@
     [RoutePrefix("static")]
     public class StaticController : ApiController
     {
+        [HttpGet]
         [Route("text")]
         public IHttpActionResult GetStaticFile()
         {

--- a/Tests/Helpers/Paths.cs
+++ b/Tests/Helpers/Paths.cs
@@ -2,7 +2,7 @@
 {
     public static class Paths
     {
-        public const string StaticContent = "static/text";
+        public const string StaticText = "static/text";
         public const string SingleResource = "api/people/123/";
         public const string ResourceCollection = "api/people/";
         public const string NonExistingPath = "api/wrong/";

--- a/Tests/Helpers/Paths.cs
+++ b/Tests/Helpers/Paths.cs
@@ -2,6 +2,7 @@
 {
     public static class Paths
     {
+        public const string StaticContent = "static/text";
         public const string SingleResource = "api/people/123/";
         public const string ResourceCollection = "api/people/";
         public const string NonExistingPath = "api/wrong/";

--- a/Tests/Integration/ContentNegotiationTests.cs
+++ b/Tests/Integration/ContentNegotiationTests.cs
@@ -165,7 +165,7 @@ namespace Tests.Integration
 
 
             [Fact(DisplayName = "Should return OK for a static content request that does not have media type parameters")]
-            public async Task MustReturn200OkForOneValidAccep1t()
+            public async Task MustReturn200OkForStaticContent()
             {
                 var target = _server.GetClient();
 

--- a/Tests/Integration/ContentNegotiationTests.cs
+++ b/Tests/Integration/ContentNegotiationTests.cs
@@ -162,6 +162,19 @@ namespace Tests.Integration
 
                 Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             }
+
+
+            [Fact(DisplayName = "Should return OK for a static content request that does not have media type parameters")]
+            public async Task MustReturn200OkForOneValidAccep1t()
+            {
+                var target = _server.GetClient();
+
+                target.DefaultRequestHeaders.Accept.Clear();
+
+                var result = await target.GetAsync(Paths.StaticText);
+
+                Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            }
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -106,6 +106,7 @@
     <Compile Include="ApiResourceTests.cs" />
     <Compile Include="Controllers\BrokenController.cs" />
     <Compile Include="Controllers\CompaniesController.cs" />
+    <Compile Include="Controllers\StaticController.cs" />
     <Compile Include="Helpers\Get.cs" />
     <Compile Include="Helpers\HttpClientExtensions.cs" />
     <Compile Include="Helpers\NewSetupJsonApiServer.cs" />


### PR DESCRIPTION
This modification checks for the presence of the JSONAPI media type within the accept header before executing the body of the PreprocessingDelegatingHandler. This prevents the handler from breaking non-API routes for static or other content. An associated test has been added against a controller serving static content. Should resolve #111 and #116.