### PR TITLE
Use included resource when serialising it’s links

### DIFF
--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -205,21 +205,22 @@ namespace Saule.Serialization
 
             foreach (var rel in resource.Relationships)
             {
-                relationships[rel.Name] = SerializeRelationship(rel, properties);
+                relationships[rel.Name] = SerializeRelationship(resource, rel, properties);
             }
 
             return relationships;
         }
 
-        private JToken SerializeRelationship(ResourceRelationship relationship, IDictionary<string, JToken> properties)
+        private JToken SerializeRelationship(ApiResource resource, ResourceRelationship relationship, IDictionary<string, JToken> properties)
         {
             var relationshipValues = GetValue(relationship.Name, properties);
             var relationshipProperties = relationshipValues as JObject;
 
             // serialize the links part (so the data can be fetched)
-            var objId = EnsureHasId(properties, _resource);
+            var objId = EnsureHasId(properties, resource);
             var relToken = GetMinimumRelationship(
                 objId.ToString(),
+                resource,
                 relationship,
                 relationshipProperties != null ? (string)GetId(relationshipProperties, relationship.RelatedResource) : null);
             if (relationshipValues == null)
@@ -263,11 +264,11 @@ namespace Saule.Serialization
             return data;
         }
 
-        private JToken GetMinimumRelationship(string id, ResourceRelationship relationship, string relationshipId)
+        private JToken GetMinimumRelationship(string id, ApiResource resource, ResourceRelationship relationship, string relationshipId)
         {
             var links = new JObject();
-            AddUrl(links, "self", _urlBuilder.BuildRelationshipPath(_resource, id, relationship));
-            AddUrl(links, "related", _urlBuilder.BuildRelationshipPath(_resource, id, relationship, relationshipId));
+            AddUrl(links, "self", _urlBuilder.BuildRelationshipPath(resource, id, relationship));
+            AddUrl(links, "related", _urlBuilder.BuildRelationshipPath(resource, id, relationship, relationshipId));
 
             return new JObject
             {

--- a/Tests/Helpers/Get.cs
+++ b/Tests/Helpers/Get.cs
@@ -41,6 +41,16 @@ namespace Tests.Helpers
             }
         }
 
+        public static IEnumerable<Customer> Customers()
+        {
+            var i = 0;
+
+            while (true)
+            {
+                yield return Customer(i++.ToString());
+            }
+        }
+
         public static IEnumerable<Person> People(int count)
         {
             return People().Take(count);
@@ -48,6 +58,11 @@ namespace Tests.Helpers
         public static IEnumerable<Company> Companies(int count)
         {
             return Companies().Take(count);
+        }
+
+        public static IEnumerable<Customer> Customers(int count)
+        {
+            return Customers().Take(count);
         }
 
         public static Person Person(string id = "123")
@@ -65,6 +80,10 @@ namespace Tests.Helpers
             {
                 Location = (LocationType)random.Next(Enum.GetNames(typeof(LocationType)).Length)
             };
+        }
+        public static Customer Customer(string id = "789")
+        {
+            return new Customer(prefill: true, id: id);
         }
     }
 }

--- a/Tests/Models/CompanyWithCustomers.cs
+++ b/Tests/Models/CompanyWithCustomers.cs
@@ -1,0 +1,15 @@
+﻿using Tests.Helpers;
+using System.Collections.Generic;
+
+namespace Tests.Models
+{
+    public class CompanyWithCustomers : Company
+    {
+        public CompanyWithCustomers(bool prefill = false, string id = "456")
+            : base (prefill, id)
+        {
+        }
+
+        public IEnumerable<Customer> Customers { get; set; }
+    }
+}

--- a/Tests/Models/CompanyWithCustomersResource.cs
+++ b/Tests/Models/CompanyWithCustomersResource.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Saule;
+
+namespace Tests.Models
+{
+    public class CompanyWithCustomersResource : CompanyResource
+    {
+        public CompanyWithCustomersResource()
+        {
+            HasMany<CustomerResource>(nameof(CompanyWithCustomers.Customers));
+        }
+    }
+}

--- a/Tests/Models/Customer.cs
+++ b/Tests/Models/Customer.cs
@@ -1,0 +1,16 @@
+﻿namespace Tests.Models
+{
+    public class Customer
+    {
+        public Customer(bool prefill = false, string id = "789")
+        {
+            Id = id;
+            if (!prefill) return;
+
+            Name = "Acme PLC";
+        }
+
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Tests/Models/CustomerResource.cs
+++ b/Tests/Models/CustomerResource.cs
@@ -1,0 +1,12 @@
+﻿using Saule;
+
+namespace Tests.Models
+{
+    public class CustomerResource : ApiResource
+    {
+        public CustomerResource()
+        {
+            Attribute(nameof(Customer.Name));
+        }
+    }
+}

--- a/Tests/Models/PersonWithCompanyWithCustomersResource.cs
+++ b/Tests/Models/PersonWithCompanyWithCustomersResource.cs
@@ -1,0 +1,16 @@
+﻿using Saule;
+
+namespace Tests.Models
+{
+    public class PersonWithCompanyWithCustomersResource : ApiResource
+    {
+        public PersonWithCompanyWithCustomersResource()
+        {
+            OfType("Person");
+
+            WithId(nameof(Person.Identifier));
+            
+            BelongsTo<CompanyWithCustomersResource>(nameof(Person.Job), "/employer");
+        }
+    }
+}

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -237,6 +237,24 @@ namespace Tests.Serialization
             Assert.NotNull(job?["attributes"]);
         }
 
+        [Fact(DisplayName = "Relationships of included resources have correct URLs")]
+        public void IncludedResourceRelationshipURLsAreCorrect()
+        {
+            var person = new Person(true)
+            {
+                Job = new CompanyWithCustomers(true)
+            };
+
+            var target = new ResourceSerializer(person, new PersonWithCompanyWithCustomersResource(),
+                GetUri(id: "123"), DefaultPathBuilder, null);
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            var included = result["included"] as JArray;
+
+            Assert.Equal("http://example.com/api/corporations/456/relationships/customers/", included?[0]?["relationships"]?["customers"]?["links"]?.Value<Uri>("self")?.ToString()); 
+        }
+
         [Fact(DisplayName = "Handles null relationships and attributes correctly")]
         public void HandlesNullValues()
         {

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -119,10 +119,15 @@
     <Compile Include="Models\CompanyResource.cs" />
     <Compile Include="Models\CompanyWithDifferentId.cs" />
     <Compile Include="Models\CompanyWithDifferentIdResource.cs" />
+    <Compile Include="Models\CompanyWithCustomers.cs" />
+    <Compile Include="Models\CompanyWithCustomersResource.cs" />
+    <Compile Include="Models\Customer.cs" />
+    <Compile Include="Models\CustomerResource.cs" />
     <Compile Include="Models\GuidAsRelation.cs" />
     <Compile Include="Models\GuidAsId.cs" />
     <Compile Include="Helpers\ObsoleteSetupJsonApiServer.cs" />
     <Compile Include="Helpers\Paths.cs" />
+    <Compile Include="Models\PersonWithCompanyWithCustomersResource.cs" />
     <Compile Include="Models\PersonWithGuidAsRelationsResource.cs" />
     <Compile Include="Models\PersonResource.cs" />
     <Compile Include="Models\PersonWithDefaultIdResource.cs" />


### PR DESCRIPTION
Whilst working on an Ember Data app, I noticed that Saule was using the root resource's URL path when generating links for included resources, rather than using the URL path of the included resource. This PR fixes this in my case.