### PR TITLE
Prevent a resource being included in both the data and included sections

### DIFF
--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -63,6 +63,17 @@ namespace Saule.Serialization
                 ["links"] = CreateTopLevelLinks(_isCollection ? objectJson.Count() : 0)
             };
 
+            if (result["data"] is JArray && _includedSection.Count > 0)
+            {
+                result["data"].Join(
+                    _includedSection,
+                    r => new { id = r["id"], type = r["type"] },
+                    i => new { id = i["id"], type = i["type"] },
+                    (r, i) => i)
+                .ToList()
+                .ForEach(i => _includedSection.Remove(i));
+            }
+
             if (_includedSection.Count > 0)
             {
                 result["included"] = _includedSection;

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -446,6 +446,9 @@ namespace Tests.Serialization
             var data = result["data"] as JArray;
             var included = result["included"] as JArray;
 
+            if (included == null)
+                return;
+
             var combined = data.Concat(included);
 
             var duplicates = combined

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -429,6 +429,34 @@ namespace Tests.Serialization
             Assert.Null(result["data"]["attributes"]["number-of-employees"]);
         }
 
+        [Fact(DisplayName = "A compound document MUST NOT include more than one resource object for each type and id pair")]
+        public void ResourceObjectsAreNotDuplicated()
+        {
+            var personA = new Person(false, "1");
+            var personB = new Person(false, "2");
+            personA.Friends = new Person[] { personB };
+            personB.Friends = new Person[] { personA };
+
+            var people = new Person[] { personA, personB };
+
+            var target = new ResourceSerializer(people, DefaultResource,
+                GetUri(), DefaultPathBuilder, null, null);
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+            var data = result["data"] as JArray;
+            var included = result["included"] as JArray;
+
+            var combined = data.Concat(included);
+
+            var duplicates = combined
+                .GroupBy(t => new { type = t["type"], id = t["id"] })
+                .Where(g => g.Count() > 1)
+                .Select(g => new { resource = g.Key, count = g.Count() })
+                .ToList();
+
+            Assert.Equal(0, duplicates.Count);
+        }
+
         private static IEnumerable<KeyValuePair<string, string>> GetQuery(string key, string value)
         {
             yield return new KeyValuePair<string, string>(key, value);


### PR DESCRIPTION
This addresses a problem I came across when Saule is serialising an array of resources. If any of the resources in the array have relationships with each other, then it will also add the related resources to the included section. 

The JSON:API spec asks that resources in compound documents should be unique across the data and included sections. http://jsonapi.org/format/#document-compound-documents

This PR trims resources from the included section where they are present in the data section once resource serialisation is complete.