### PR TITLE
Fix regression missing 'data' key for relationships when using DisableDefaultIncluded

### DIFF
--- a/Saule/Serialization/ResourceGraph.cs
+++ b/Saule/Serialization/ResourceGraph.cs
@@ -51,7 +51,8 @@ namespace Saule.Serialization
             object obj,
             ApiResource resource,
             ResourceGraphPathSet includePaths,
-            int depth)
+            int depth,
+            string propertyName = null)
         {
             if (obj == null)
             {
@@ -76,7 +77,7 @@ namespace Saule.Serialization
             if (existingNode == null)
             {
                 // this is the first time we have seen this node
-                existingNode = new ResourceGraphNode(obj, resource, includePaths, depth);
+                existingNode = new ResourceGraphNode(obj, resource, includePaths, depth, propertyName);
             }
             else if (!existingNode.IncludePaths.Equals(includePaths))
             {
@@ -90,7 +91,7 @@ namespace Saule.Serialization
                  */
 
                 includePaths = existingNode.IncludePaths.Union(includePaths);
-                existingNode = new ResourceGraphNode(obj, resource, includePaths, depth);
+                existingNode = new ResourceGraphNode(obj, resource, includePaths, depth, propertyName);
             }
             else if (existingNode.GraphDepth > depth)
             {
@@ -125,7 +126,7 @@ namespace Saule.Serialization
                         foreach (var o in collection)
                         {
                             // Add the relationship member to the graph
-                            Build(o, r.RelatedResource, childIncludes, depth + 1);
+                            Build(o, r.RelatedResource, childIncludes, depth + 1, r.PropertyName);
                         }
                     }
                 }
@@ -135,7 +136,7 @@ namespace Saule.Serialization
                     if (o != null)
                     {
                         // Add the relationship member to the graph
-                        Build(o, r.RelatedResource, childIncludes, depth + 1);
+                        Build(o, r.RelatedResource, childIncludes, depth + 1, r.PropertyName);
                     }
                 }
             }

--- a/Saule/Serialization/ResourceGraphNode.cs
+++ b/Saule/Serialization/ResourceGraphNode.cs
@@ -14,7 +14,8 @@ namespace Saule.Serialization
             object obj,
             ApiResource resource,
             ResourceGraphPathSet includePaths,
-            int graphDepth)
+            int graphDepth,
+            string propertyName = null)
         {
             obj.ThrowIfNull(nameof(obj));
             resource.ThrowIfNull(nameof(resource));
@@ -23,6 +24,7 @@ namespace Saule.Serialization
             Key = new ResourceGraphNodeKey(obj, resource);
             SourceObject = obj;
             IncludePaths = includePaths;
+            PropertyName = propertyName;
             Resource = resource;
             GraphDepth = graphDepth;
 
@@ -43,6 +45,8 @@ namespace Saule.Serialization
         public ApiResource Resource { get; private set; }
 
         public int GraphDepth { get; set; }
+
+        public string PropertyName { get; private set; }
 
         public IReadOnlyDictionary<string, ResourceGraphRelationship> Relationships { get; private set; }
     }

--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -86,7 +86,7 @@ namespace Saule.Serialization
             }
             else if (context.DisableDefaultIncluded)
             {
-                return new ResourceGraphPathSet.None();
+                return new ResourceGraphPathSet.All();
             }
             else
             {
@@ -164,6 +164,11 @@ namespace Saule.Serialization
 
         private JArray SerializeIncludes(ResourceGraph graph)
         {
+            if (_includingContext != null && _includingContext.DisableDefaultIncluded)
+            {
+                return null;
+            }
+
             var tokens = graph.IncludedNodes.Select(n => SerializeNode(n, true));
             if (tokens.Count() == 0)
             {

--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -85,10 +85,6 @@ namespace Saule.Serialization
             {
                 return new ResourceGraphPathSet(_includingContext.Includes.Select(i => i.Name));
             }
-            else if (context.DisableDefaultIncluded)
-            {
-                return new ResourceGraphPathSet.All();
-            }
             else
             {
                 return new ResourceGraphPathSet.All();

--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -175,12 +175,24 @@ namespace Saule.Serialization
 
         private JArray SerializeIncludes(ResourceGraph graph)
         {
+            var nodes = graph.IncludedNodes;
+
+            // if we have an including context and DisableDefaultIncluded is set
             if (_includingContext != null && _includingContext.DisableDefaultIncluded)
             {
-                return null;
+                // if we have specific includes filter nodes otherwise bail with null
+                if (_includingContext.Includes != null)
+                {
+                    nodes = nodes.Where(n => _includingContext.Includes.Any(p => p.Name == n.PropertyName));
+                }
+                else
+                {
+                    return null;
+                }
             }
 
-            var tokens = graph.IncludedNodes.Select(n => SerializeNode(n, true));
+            var tokens = nodes.Select(n => SerializeNode(n, true));
+
             if (tokens.Count() == 0)
             {
                 return null;

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -277,6 +277,23 @@ namespace Tests.Serialization
             Assert.Null(included);
         }
 
+        [Fact(DisplayName = "Serialize relationship identifier objects into 'data' key when includedDefault set to false")]
+        public void IncludedRelationshipIdentifierObjects()
+        {
+            var includes = new IncludingContext();
+            includes.DisableDefaultIncluded = true;
+            var target = new ResourceSerializer(DefaultObject, DefaultResource,
+                GetUri(id: "123"), DefaultPathBuilder, null, includes);
+
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            var relationships = result["data"]["relationships"];
+            var job = relationships["job"];
+
+            Assert.NotNull(job["data"]);
+        }
+
         [Fact(DisplayName = "Relationships of included resources have correct URLs")]
         public void IncludedResourceRelationshipURLsAreCorrect()
         {

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -357,8 +357,8 @@ namespace Tests.Serialization
             Assert.NotNull(attributes["last-name"]);
             Assert.NotNull(attributes["age"]);
 
-            Assert.Null(relationships["job"]["data"]);
-            Assert.Null(relationships["friends"]["data"]);
+            Assert.Equal(0, relationships["job"]["data"].Count());
+            Assert.Equal(0, relationships["friends"]["data"].Count());
         }
 
         [Fact(DisplayName = "Serializes enumerables properly")]

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -277,6 +277,24 @@ namespace Tests.Serialization
             Assert.Null(included);
         }
 
+        [Fact(DisplayName = "Serialize only included relationship data into 'included' key when includedDefault set to false")]
+        public void OnlyIncludedRelationshipData()
+        {
+            var includes = new IncludingContext();
+            includes.DisableDefaultIncluded = true;
+            var includeParam = new KeyValuePair<string, string>("include", "job");
+            includes.SetIncludes(new List<KeyValuePair<string, string>>() { includeParam });
+            var target = new ResourceSerializer(DefaultObject, DefaultResource,
+                GetUri(id: "123"), DefaultPathBuilder, null, includes);
+
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            var included = result["included"] as JArray;
+
+            Assert.Equal(1, included.Count());
+        }
+
         [Fact(DisplayName = "Serialize relationship identifier objects into 'data' key when includedDefault set to false")]
         public void IncludedRelationshipIdentifierObjects()
         {


### PR DESCRIPTION
Initially this PR added a test that fails on master but passes in stable to demonstrate the issue. The issue only reveals itself when DisableDefaultIncluded is used.

Now a fix is also included in this PR. It includes relationship data in the graph when using `DisableDefaultIncluded`, adds information of the parent property name for nodes which are children. It then uses this information when serializing the `includes` value.

Ping @laurence79.