### PR TITLE
Added pagination page size

### DIFF
--- a/Saule/Constants.cs
+++ b/Saule/Constants.cs
@@ -15,9 +15,15 @@
         public static class QueryNames
         {
             public const string PageNumber = "page.number";
+            public const string PageSize = "page.size";
             public const string Sorting = "sort";
             public const string Filtering = "filter";
             public const string Including = "include";
+        }
+
+        public static class QueryValues
+        {
+            public const int ValueNotSpecified = -1;
         }
     }
 }

--- a/Saule/Http/JsonApiConfiguration.cs
+++ b/Saule/Http/JsonApiConfiguration.cs
@@ -10,6 +10,14 @@ namespace Saule.Http
     public class JsonApiConfiguration
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="JsonApiConfiguration"/> class.
+        /// </summary>
+        public JsonApiConfiguration()
+        {
+            PaginationConfig = PaginationConfig.FromWebConfig();
+        }
+
+        /// <summary>
         /// Gets or sets the UrlPathBuilder which determines how to generate urls for links.
         /// </summary>
         public IUrlPathBuilder UrlPathBuilder { get; set; } = null;
@@ -23,5 +31,10 @@ namespace Saule.Http
         /// Gets the expressions that are used to evaluate filter queries on a per-type basis.
         /// </summary>
         public QueryFilterExpressionCollection QueryFilterExpressions { get; } = new QueryFilterExpressionCollection();
+
+        /// <summary>
+        /// Gets or sets configurable defaults to use for query pagination.
+        /// </summary>
+        public PaginationConfig PaginationConfig { get; set; }
     }
 }

--- a/Saule/Http/JsonApiConfiguration.cs
+++ b/Saule/Http/JsonApiConfiguration.cs
@@ -14,7 +14,7 @@ namespace Saule.Http
         /// </summary>
         public JsonApiConfiguration()
         {
-            PaginationConfig = PaginationConfig.FromWebConfig();
+            PaginationConfig = new PaginationConfig();
         }
 
         /// <summary>

--- a/Saule/Http/PaginationConfig.cs
+++ b/Saule/Http/PaginationConfig.cs
@@ -8,19 +8,6 @@ namespace Saule.Http
     public class PaginationConfig
     {
         /// <summary>
-        /// Web.Config appSettings key for the default page size.
-        /// </summary>
-        public const string PageSizeAppSettingKey = "JsonApi.PageSizeDefault";
-
-        /// <summary>
-        /// Web.Config appSettings key for the default limit for page[size] query parameter values.
-        /// </summary>
-        /// <remarks>
-        /// Omitting this value from configuration will result in the page[size] query parameter being ignored.
-        /// </remarks>
-        public const string PageSizeLimitKey = "JsonApi.PageSizeLimit";
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="PaginationConfig"/> class.
         /// </summary>
         public PaginationConfig()
@@ -41,37 +28,5 @@ namespace Saule.Http
         /// not specify a MaxClientPageSize value.
         /// </summary>
         public int? DefaultPageSizeLimit { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether or not page[size] query string parameters will be honored.
-        /// </summary>
-        public bool AllowQueryPageSize
-        {
-            get { return DefaultPageSizeLimit.HasValue; }
-        }
-
-        /// <summary>
-        /// Create pagination configuration from web.config app settings.
-        /// </summary>
-        /// <returns>PaginationConfig instance with values from web.config.</returns>
-        public static PaginationConfig FromWebConfig()
-        {
-            // defaulting to 10 for compatibility with existing Saule conventions
-            var paginationConfig = new PaginationConfig();
-
-            int configDefaultPageSize;
-            if (int.TryParse(ConfigurationManager.AppSettings[PageSizeAppSettingKey], out configDefaultPageSize))
-            {
-                paginationConfig.DefaultPageSize = configDefaultPageSize;
-            }
-
-            int configPageSizeLimit;
-            if (int.TryParse(ConfigurationManager.AppSettings[PageSizeLimitKey], out configPageSizeLimit))
-            {
-                paginationConfig.DefaultPageSizeLimit = configPageSizeLimit;
-            }
-
-            return paginationConfig;
-        }
     }
 }

--- a/Saule/Http/PaginationConfig.cs
+++ b/Saule/Http/PaginationConfig.cs
@@ -1,0 +1,77 @@
+﻿using System.Configuration;
+
+namespace Saule.Http
+{
+    /// <summary>
+    /// Pagination configuration.  Property values can be set programmatically or be read from web.config app settings.
+    /// </summary>
+    public class PaginationConfig
+    {
+        /// <summary>
+        /// Web.Config appSettings key for the default page size.
+        /// </summary>
+        public const string PageSizeAppSettingKey = "JsonApi.PageSizeDefault";
+
+        /// <summary>
+        /// Web.Config appSettings key for the default limit for page[size] query parameter values.
+        /// </summary>
+        /// <remarks>
+        /// Omitting this value from configuration will result in the page[size] query parameter being ignored.
+        /// </remarks>
+        public const string PageSizeLimitKey = "JsonApi.PageSizeLimit";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PaginationConfig"/> class.
+        /// </summary>
+        public PaginationConfig()
+        {
+            // TODO: for compatibility with legacy code only.  Recommend doing away with this in favor of app level configuration
+            DefaultPageSize = 10;
+        }
+
+        /// <summary>
+        /// Gets or sets default page size to use for query actions decorated
+        /// with a [Paginated] attribute that does not specify a PerPage value.
+        /// </summary>
+        public int DefaultPageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default value to use for the maximum allowable page
+        /// size to accept from the client with a [Paginated] attribute that does
+        /// not specify a MaxClientPageSize value.
+        /// </summary>
+        public int? DefaultPageSizeLimit { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not page[size] query string parameters will be honored.
+        /// </summary>
+        public bool AllowQueryPageSize
+        {
+            get { return DefaultPageSizeLimit.HasValue; }
+        }
+
+        /// <summary>
+        /// Create pagination configuration from web.config app settings.
+        /// </summary>
+        /// <returns>PaginationConfig instance with values from web.config.</returns>
+        public static PaginationConfig FromWebConfig()
+        {
+            // defaulting to 10 for compatibility with existing Saule conventions
+            var paginationConfig = new PaginationConfig();
+
+            int configDefaultPageSize;
+            if (int.TryParse(ConfigurationManager.AppSettings[PageSizeAppSettingKey], out configDefaultPageSize))
+            {
+                paginationConfig.DefaultPageSize = configDefaultPageSize;
+            }
+
+            int configPageSizeLimit;
+            if (int.TryParse(ConfigurationManager.AppSettings[PageSizeLimitKey], out configPageSizeLimit))
+            {
+                paginationConfig.DefaultPageSizeLimit = configPageSizeLimit;
+            }
+
+            return paginationConfig;
+        }
+    }
+}

--- a/Saule/Http/PreprocessingDelegatingHandler.cs
+++ b/Saule/Http/PreprocessingDelegatingHandler.cs
@@ -144,8 +144,7 @@ namespace Saule.Http
                     pagination.PageSizeLimit = config.PaginationConfig.DefaultPageSizeLimit;
                 }
 
-                // page size limit needs to be configured if we're going to accept client/query page sizes
-                if (!pagination.PerPage.HasValue || (pagination.IsPageSizeFromQuery && !pagination.PageSizeLimit.HasValue))
+                if (!pagination.PerPage.HasValue)
                 {
                     pagination.PerPage = config.PaginationConfig.DefaultPageSize;
                 }

--- a/Saule/Queries/Pagination/PaginationContext.cs
+++ b/Saule/Queries/Pagination/PaginationContext.cs
@@ -24,7 +24,7 @@ namespace Saule.Queries.Pagination
         public int Page { get; }
 
         public int? PerPage { get; set; }
-        
+
         public int? PageSizeLimit { get; set; }
 
         public IDictionary<string, string> ClientFilters { get; }

--- a/Saule/Queries/Pagination/PaginationContext.cs
+++ b/Saule/Queries/Pagination/PaginationContext.cs
@@ -24,6 +24,7 @@ namespace Saule.Queries.Pagination
         public int Page { get; }
 
         public int? PerPage { get; set; }
+        
         public int? PageSizeLimit { get; set; }
 
         public IDictionary<string, string> ClientFilters { get; }

--- a/Saule/Queries/Pagination/PaginationContext.cs
+++ b/Saule/Queries/Pagination/PaginationContext.cs
@@ -24,10 +24,7 @@ namespace Saule.Queries.Pagination
         public int Page { get; }
 
         public int? PerPage { get; set; }
-
         public int? PageSizeLimit { get; set; }
-
-        public bool IsPageSizeFromQuery { get; private set; }
 
         public IDictionary<string, string> ClientFilters { get; }
 
@@ -46,7 +43,6 @@ namespace Saule.Queries.Pagination
         private int? GetSize(int? defaultSize)
         {
             int? queryPageSize = ClientFilters.GetInt(Constants.QueryNames.PageSize);
-            IsPageSizeFromQuery = queryPageSize.HasValue;
             return queryPageSize ?? defaultSize;
         }
     }

--- a/Saule/Saule.csproj
+++ b/Saule/Saule.csproj
@@ -48,6 +48,7 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
@@ -57,15 +58,15 @@
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiResource.cs" />
+    <Compile Include="Http\PaginationConfig.cs" />
+    <Compile Include="JsonApiSerializerOfT.cs" />
+    <Compile Include="StringDictionaryExtensions.cs" />
     <Compile Include="Http\DisableDefaultIncludedAttribute.cs" />
     <Compile Include="Http\AllowsQueryAttribute.cs" />
     <Compile Include="Http\HttpConfigExtensions.cs" />
@@ -78,7 +79,6 @@
     <Compile Include="Http\QueryContextUtils.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="JsonApiSerializer.cs" />
-    <Compile Include="JsonApiSerializerOfT.cs" />
     <Compile Include="LinkType.cs" />
     <Compile Include="NullGuardExtensions.cs" />
     <Compile Include="ObjectExtensions.cs" />

--- a/Saule/StringDictionaryExtensions.cs
+++ b/Saule/StringDictionaryExtensions.cs
@@ -6,7 +6,7 @@ namespace Saule
     /// <summary>
     /// Extension methods for operating on IDictionary[string, string]
     /// </summary>
-    public static class StringDictionaryExtensions
+    internal static class StringDictionaryExtensions
     {
         /// <summary>
         /// Parse an integer value from a dictionary.

--- a/Saule/StringDictionaryExtensions.cs
+++ b/Saule/StringDictionaryExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Saule
+{
+    /// <summary>
+    /// Extension methods for operating on IDictionary[string, string]
+    /// </summary>
+    public static class StringDictionaryExtensions
+    {
+        /// <summary>
+        /// Parse an integer value from a dictionary.
+        /// </summary>
+        /// <param name="dictionary">Dictionary being interrogated</param>
+        /// <param name="key">Key for the value to be parsed</param>
+        /// <returns>Int32 parsed from dictionary value</returns>
+        public static int? GetInt(this IDictionary<string, string> dictionary, string key)
+        {
+            string keyValue;
+            dictionary.TryGetValue(key, out keyValue);
+            int intValue;
+            bool legit = int.TryParse(keyValue, out intValue);
+            return legit ? intValue : (int?)null;
+        }
+
+        /// <summary>
+        /// Parse an integer value from a dictionary.
+        /// </summary>
+        /// <param name="dictionary">Dictionary being interrogated</param>
+        /// <param name="key">Key for the value to be parsed</param>
+        /// <param name="defaultValue">Default value for unparsable keys</param>
+        /// <returns>Int32 parsed from dictionary value</returns>
+        public static int GetInt(this IDictionary<string, string> dictionary, string key, int defaultValue)
+        {
+            return GetInt(dictionary, key) ?? defaultValue;
+        }
+    }
+}

--- a/Tests/Controllers/CompaniesController.cs
+++ b/Tests/Controllers/CompaniesController.cs
@@ -36,5 +36,23 @@ namespace Tests.Controllers
         {
             return Get.Companies(100);
         }
+
+        [HttpGet]
+        [Paginated(PerPage = 12)]
+        [Route("companies/querypagesize")]
+        [ReturnsResource(typeof(CompanyResource))]
+        public IEnumerable<Company> GetCompaniesQueryPageSize()
+        {
+            return Get.Companies(100);
+        }
+
+        [HttpGet]
+        [Paginated(PerPage = 12, PageSizeLimit = 50)]
+        [Route("companies/querypagesizelimit50")]
+        [ReturnsResource(typeof(CompanyResource))]
+        public IEnumerable<Company> GetCompaniesQueryPageSizeLimit50()
+        {
+            return Get.Companies(100);
+        }
     }
 }

--- a/Tests/Serialization/UrlConstructionTests.cs
+++ b/Tests/Serialization/UrlConstructionTests.cs
@@ -102,7 +102,7 @@ namespace Tests.Serialization
             var people = Get.People(5);
             var target = new ResourceSerializer(people, new PersonResource(),
                 GetUri(), DefaultPathBuilder,
-                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "2"), perPage: 10), null);
+                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "2"), pageSizeDefault: 10), null);
             var result = target.Serialize();
             _output.WriteLine(result.ToString());
 
@@ -110,7 +110,7 @@ namespace Tests.Serialization
 
             target = new ResourceSerializer(people, new PersonResource(),
                 GetUri(), DefaultPathBuilder,
-                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "2"), perPage: 4), null);
+                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "2"), pageSizeDefault: 4), null);
             result = target.Serialize();
 
             var nextLink = Uri.UnescapeDataString(result["links"].Value<Uri>("next").Query);
@@ -123,7 +123,7 @@ namespace Tests.Serialization
             var people = Get.People(5);
             var target = new ResourceSerializer(people, new PersonResource(),
                 GetUri(), DefaultPathBuilder,
-                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "0"), perPage: 10), null);
+                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "0"), pageSizeDefault: 10), null);
             var result = target.Serialize();
             _output.WriteLine(result.ToString());
 
@@ -131,7 +131,7 @@ namespace Tests.Serialization
 
             target = new ResourceSerializer(people, new PersonResource(),
                 GetUri(), DefaultPathBuilder,
-                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "1"), perPage: 10), null);
+                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "1"), pageSizeDefault: 10), null);
             result = target.Serialize();
 
             var nextLink = Uri.UnescapeDataString(result["links"].Value<Uri>("prev").Query);
@@ -144,7 +144,7 @@ namespace Tests.Serialization
             var people = Get.People(5);
             var target = new ResourceSerializer(people, new PersonResource(),
                 GetUri(query: "q=a"), DefaultPathBuilder,
-                new PaginationContext(GetQuery("q", "a"), perPage: 4), null);
+                new PaginationContext(GetQuery("q", "a"), pageSizeDefault: 4), null);
 
             var result = target.Serialize();
             _output.WriteLine(result.ToString());
@@ -159,7 +159,7 @@ namespace Tests.Serialization
             var people = Get.People(5);
             var target = new ResourceSerializer(people, new PersonResource(),
                GetUri(), DefaultPathBuilder,
-                new PaginationContext(Enumerable.Empty<KeyValuePair<string, string>>(), perPage: 4), null);
+                new PaginationContext(Enumerable.Empty<KeyValuePair<string, string>>(), pageSizeDefault: 4), null);
 
             var result = target.Serialize();
             _output.WriteLine(result.ToString());

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>CS0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/docs/Pagination.md
+++ b/docs/Pagination.md
@@ -9,7 +9,7 @@ Adding pagination to an action method's results is as easy as adding an attribut
 ```csharp
 public class PeopleController : ApiController
 {
-    [Paginate(PerPage = 25)]
+    [Paginate(PerPage = 25, PageSizeLimit = 100)]
     [ReturnsResource(typeof(PersonResource))]
     public IQueryable<Person> Get()
     {
@@ -18,9 +18,33 @@ public class PeopleController : ApiController
 }
 ```
 
-This will generate `next`, `prev` and `first` links in your responses, add interpret the page[number]
-query parameter when appropriate.
+This will generate `next`, `prev` and `first` links in your responses, and interpret the page[number]
+and page[size] query parameter when appropriate.
 
 Saule will use LINQ to query the `IQueryable<T>` you return, so pagination is not done in memory.
 If you return an `IEnumerable<T>`, the query is executed in memory instead. Note that Saule does
 not support the non-generic versions of `IQueryable` and `IEnumerable`.
+
+Default values for pagination can be provided with the `JsonApiConfiguration` for your application.  When the optional PerPage or PageSizeLimit values are omitted from the Paginate attribute, those settings are taken from the `JsonApiConfiguration` defaults:
+
+```csharp
+public static class WebApiConfig
+{
+    public static void Register(HttpConfiguration config)
+    {
+        // Web API routes
+        config.MapHttpAttributeRoutes();
+
+        config.ConfigureJsonApi(new JsonApiConfiguration
+        {
+            PaginationConfig = new PaginationConfig
+            {
+                DefaultPageSize = 25,
+                DefaultPageSizeLimit = 100
+            }
+        });
+    }
+}
+```
+
+If `PaginationConfig` is not specified for the `JsonApiConfiguration`, the default page size is 10 and there is no default page size limit.


### PR DESCRIPTION
This pull request is for issue #128 (https://github.com/joukevandermaas/saule/issues/128#issuecomment-312198306).  Default values for page size and page size limits can be configured imperatively at app start with the JsonApiConfiguration.PaginationConfig property, or with web.config appSetting values.  See the PaginationConfig PageSizeAppSettingKey and PageSizeLimitKey constants.  The Pagination attribute has had a PageSizeLimit property added for overriding the application default values.

I hold the opinion that with page[size] from the query implemented, that the default of 10 as it existed with the Pagination attribute should be done away with, and that the library should require both page[number] and page[size] if either is supplied, but this implementation has the page size default set to 10 for compatibility with legacy versions of Saule.

This is my first time contributing to any open source projects, so my apologies in advance if there are issues with this pull request.