### PR TITLE
configureJsonApi overload (formatter can be only add at end of the collection, without delete other formatters

### DIFF
--- a/Saule/ConfigureFormattersEnum.cs
+++ b/Saule/ConfigureFormattersEnum.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Saule
+{
+    /// <summary>
+    /// Configuration enum for formatters
+    /// </summary>
+    public enum ConfigureFormattersEnum
+    {
+        /// <summary>
+        /// Formatter will be inserted at the start of the collection
+        /// </summary>
+        AddFormatterToStart = 0,
+
+        /// <summary>
+        /// Formatter will be inserted at the end of the collection
+        /// </summary>
+        AddFormatterToEnd = 1,
+
+        /// <summary>
+        /// Other formatters will be cleared
+        /// </summary>
+        OverwriteOtherFormatters = 2,
+    }
+}

--- a/Saule/FormatterPriority.cs
+++ b/Saule/FormatterPriority.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 namespace Saule
 {
     /// <summary>
-    /// Configuration enum for formatters
+    /// Formatter priority for configuration
     /// </summary>
-    public enum ConfigureFormattersEnum
+    public enum FormatterPriority
     {
         /// <summary>
         /// Formatter will be inserted at the start of the collection

--- a/Saule/Http/HttpConfigExtensions.cs
+++ b/Saule/Http/HttpConfigExtensions.cs
@@ -50,11 +50,11 @@ namespace Saule.Http
         {
             if (overwriteOtherFormatters)
             {
-                ConfigureJsonApi(config, jsonApiConfiguration, ConfigureFormattersEnum.OverwriteOtherFormatters);
+                ConfigureJsonApi(config, jsonApiConfiguration, FormatterPriority.OverwriteOtherFormatters);
             }
             else
             {
-                ConfigureJsonApi(config, jsonApiConfiguration, ConfigureFormattersEnum.AddFormatterToStart);
+                ConfigureJsonApi(config, jsonApiConfiguration, FormatterPriority.AddFormatterToStart);
             }
         }
 
@@ -63,29 +63,25 @@ namespace Saule.Http
         /// </summary>
         /// <param name="config">The <see cref="HttpConfiguration"/> that is used in the setup of the application.</param>
         /// <param name="jsonApiConfiguration">Configuration parameters for Json Api serialization.</param>
-        /// <param name="configureFormatters">
-        /// AddFormatterToStart - Formatter will be inserted at the start of the collection.
-        /// AddFormatterToEnd - Formatter will be inserted at the end of the collection.
-        /// OverwriteOtherFormatters -  Other formatters will be cleared.
-        /// </param>
+        /// <param name="formatterPriority"> Determines the relative position of the JSON API formatter.</param>
         public static void ConfigureJsonApi(
           this HttpConfiguration config,
           JsonApiConfiguration jsonApiConfiguration,
-          ConfigureFormattersEnum configureFormatters)
+          FormatterPriority formatterPriority)
         {
             config.MessageHandlers.Add(new PreprocessingDelegatingHandler(jsonApiConfiguration));
             var formatter = new JsonApiMediaTypeFormatter(jsonApiConfiguration);
 
-            if (configureFormatters == ConfigureFormattersEnum.OverwriteOtherFormatters)
+            if (formatterPriority == FormatterPriority.OverwriteOtherFormatters)
             {
                 config.Formatters.Clear();
                 config.Formatters.Add(formatter);
             }
-            else if (configureFormatters == ConfigureFormattersEnum.AddFormatterToEnd)
+            else if (formatterPriority == FormatterPriority.AddFormatterToEnd)
             {
                 config.Formatters.Add(formatter);
             }
-            else if (configureFormatters == ConfigureFormattersEnum.AddFormatterToStart)
+            else if (formatterPriority == FormatterPriority.AddFormatterToStart)
             {
                 config.Formatters.Insert(0, formatter);
             }

--- a/Saule/Http/HttpConfigExtensions.cs
+++ b/Saule/Http/HttpConfigExtensions.cs
@@ -48,18 +48,49 @@ namespace Saule.Http
             JsonApiConfiguration jsonApiConfiguration,
             bool overwriteOtherFormatters)
         {
+            if (overwriteOtherFormatters)
+            {
+                ConfigureJsonApi(config, jsonApiConfiguration, ConfigureFormattersEnum.OverwriteOtherFormatters);
+            }
+            else
+            {
+                ConfigureJsonApi(config, jsonApiConfiguration, ConfigureFormattersEnum.AddFormatterToStart);
+            }
+
+        }
+
+        /// <summary>
+        ///  Sets up serialization and deserialization of Json Api resources.
+        /// </summary>
+        /// <param name="config">The <see cref="HttpConfiguration"/> that is used in the setup of the application.</param>
+        /// <param name="jsonApiConfiguration">Configuration parameters for Json Api serialization.</param>
+        /// <param name="configureFormatters">
+        /// AddFormatterToStart - Formatter will be inserted at the start of the collection.
+        /// AddFormatterToEnd - Formatter will be inserted at the end of the collection.
+        /// OverwriteOtherFormatters -  Other formatters will be cleared.
+        /// </param>
+        public static void ConfigureJsonApi(
+          this HttpConfiguration config,
+          JsonApiConfiguration jsonApiConfiguration,
+          ConfigureFormattersEnum configureFormatters)
+        {
             config.MessageHandlers.Add(new PreprocessingDelegatingHandler(jsonApiConfiguration));
             var formatter = new JsonApiMediaTypeFormatter(jsonApiConfiguration);
 
-            if (overwriteOtherFormatters)
+            if (configureFormatters == ConfigureFormattersEnum.OverwriteOtherFormatters)
             {
                 config.Formatters.Clear();
                 config.Formatters.Add(formatter);
             }
-            else
+            else if (configureFormatters == ConfigureFormattersEnum.AddFormatterToEnd)
+            {
+                config.Formatters.Add(formatter);
+            }
+            else if (configureFormatters == ConfigureFormattersEnum.AddFormatterToStart)
             {
                 config.Formatters.Insert(0, formatter);
             }
         }
+
     }
 }

--- a/Saule/Http/HttpConfigExtensions.cs
+++ b/Saule/Http/HttpConfigExtensions.cs
@@ -91,6 +91,5 @@ namespace Saule.Http
                 config.Formatters.Insert(0, formatter);
             }
         }
-
     }
 }

--- a/Saule/Http/HttpConfigExtensions.cs
+++ b/Saule/Http/HttpConfigExtensions.cs
@@ -56,7 +56,6 @@ namespace Saule.Http
             {
                 ConfigureJsonApi(config, jsonApiConfiguration, ConfigureFormattersEnum.AddFormatterToStart);
             }
-
         }
 
         /// <summary>

--- a/Saule/Saule.csproj
+++ b/Saule/Saule.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiResource.cs" />
-    <Compile Include="ConfigureFormattersEnum.cs" />
+    <Compile Include="FormatterPriority.cs" />
     <Compile Include="Http\DisableDefaultIncludedAttribute.cs" />
     <Compile Include="Http\AllowsQueryAttribute.cs" />
     <Compile Include="Http\HttpConfigExtensions.cs" />

--- a/Saule/Saule.csproj
+++ b/Saule/Saule.csproj
@@ -66,6 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiResource.cs" />
+    <Compile Include="ConfigureFormattersEnum.cs" />
     <Compile Include="Http\DisableDefaultIncludedAttribute.cs" />
     <Compile Include="Http\AllowsQueryAttribute.cs" />
     <Compile Include="Http\HttpConfigExtensions.cs" />


### PR DESCRIPTION
I added more options for configure formatters in ConfigureJsonApi. For example if want combinate JSON API with WebAPI together.
#167 