### PR TITLE
Made ResourceDeserializer public

### DIFF
--- a/Saule/JsonApiSerializerOfT.cs
+++ b/Saule/JsonApiSerializerOfT.cs
@@ -97,7 +97,7 @@ namespace Saule
         /// <param name="object">Json to convert</param>
         /// <param name="type">Type to convert to</param>
         /// <returns>Json converted into the specified type of object</returns>
-        public dynamic Deserialize(JToken @object, Type type)
+        public object Deserialize(JToken @object, Type type)
         {
             var target = new ResourceDeserializer(@object, type);
             return target.Deserialize();

--- a/Saule/JsonApiSerializerOfT.cs
+++ b/Saule/JsonApiSerializerOfT.cs
@@ -91,6 +91,18 @@ namespace Saule
             return JsonApiSerializer.Serialize(preprocessResult);
         }
 
+        /// <summary>
+        /// Converts json into an object of a specified type
+        /// </summary>
+        /// <param name="object">Json to convert</param>
+        /// <param name="type">Type to convert to</param>
+        /// <returns>Json converted into the specified type of object</returns>
+        public dynamic Deserialize(JToken @object, Type type)
+        {
+            var target = new ResourceDeserializer(@object, type);
+            return target.Deserialize();
+        }
+
         private QueryContext GetQueryContext(IEnumerable<KeyValuePair<string, string>> filters)
         {
             var context = new QueryContext();

--- a/Saule/Serialization/ResourceDeserializer.cs
+++ b/Saule/Serialization/ResourceDeserializer.cs
@@ -20,6 +20,8 @@ namespace Saule.Serialization
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceDeserializer"/> class.
         /// </summary>
+        /// <param name="object">Json token we want to convert into an object</param>
+        /// <param name="target">The type of object the json token should be converted into</param>
         public ResourceDeserializer(JToken @object, Type target)
         {
             _object = @object;
@@ -29,6 +31,7 @@ namespace Saule.Serialization
         /// <summary>
         /// Deserialize the contained json into the specified type of object
         /// </summary>
+        /// <returns>Json converted into the specified type of object</returns>
         public object Deserialize()
         {
             ValidateTopLevel(_object);

--- a/Saule/Serialization/ResourceDeserializer.cs
+++ b/Saule/Serialization/ResourceDeserializer.cs
@@ -13,7 +13,7 @@ namespace Saule.Serialization
 
         private readonly JToken _object;
         private readonly Type _target;
-        
+
         public ResourceDeserializer(JToken @object, Type target)
         {
             _object = @object;

--- a/Saule/Serialization/ResourceDeserializer.cs
+++ b/Saule/Serialization/ResourceDeserializer.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Saule.Serialization
 {
-    internal class ResourceDeserializer
+    public class ResourceDeserializer
     {
         private static string[] _allowedTopLevelMembers = new[]
         {

--- a/Saule/Serialization/ResourceDeserializer.cs
+++ b/Saule/Serialization/ResourceDeserializer.cs
@@ -4,6 +4,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Saule.Serialization
 {
+    /// <summary>
+    /// Deserializes json into a specified type of object
+    /// </summary>
     public class ResourceDeserializer
     {
         private static string[] _allowedTopLevelMembers = new[]
@@ -14,12 +17,19 @@ namespace Saule.Serialization
         private readonly JToken _object;
         private readonly Type _target;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResourceDeserializer"/> class.
+        /// </summary>
         public ResourceDeserializer(JToken @object, Type target)
         {
             _object = @object;
             _target = target;
         }
 
+        /// <summary>
+        /// Deserialize the contained json into the specified type of object
+        /// </summary>
+        /// <returns></returns>
         public object Deserialize()
         {
             ValidateTopLevel(_object);

--- a/Saule/Serialization/ResourceDeserializer.cs
+++ b/Saule/Serialization/ResourceDeserializer.cs
@@ -29,7 +29,6 @@ namespace Saule.Serialization
         /// <summary>
         /// Deserialize the contained json into the specified type of object
         /// </summary>
-        /// <returns></returns>
         public object Deserialize()
         {
             ValidateTopLevel(_object);

--- a/Saule/Serialization/ResourceDeserializer.cs
+++ b/Saule/Serialization/ResourceDeserializer.cs
@@ -4,9 +4,6 @@ using Newtonsoft.Json.Linq;
 
 namespace Saule.Serialization
 {
-    /// <summary>
-    /// Deserializes json into a specified type of object
-    /// </summary>
     internal class ResourceDeserializer
     {
         private static string[] _allowedTopLevelMembers = new[]
@@ -16,22 +13,13 @@ namespace Saule.Serialization
 
         private readonly JToken _object;
         private readonly Type _target;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ResourceDeserializer"/> class.
-        /// </summary>
-        /// <param name="object">Json token we want to convert into an object</param>
-        /// <param name="target">The type of object the json token should be converted into</param>
+        
         public ResourceDeserializer(JToken @object, Type target)
         {
             _object = @object;
             _target = target;
         }
 
-        /// <summary>
-        /// Deserialize the contained json into the specified type of object
-        /// </summary>
-        /// <returns>Json converted into the specified type of object</returns>
         public object Deserialize()
         {
             ValidateTopLevel(_object);

--- a/Saule/Serialization/ResourceDeserializer.cs
+++ b/Saule/Serialization/ResourceDeserializer.cs
@@ -7,7 +7,7 @@ namespace Saule.Serialization
     /// <summary>
     /// Deserializes json into a specified type of object
     /// </summary>
-    public class ResourceDeserializer
+    internal class ResourceDeserializer
     {
         private static string[] _allowedTopLevelMembers = new[]
         {

--- a/Tests/JsonApiSerializerTests.cs
+++ b/Tests/JsonApiSerializerTests.cs
@@ -277,7 +277,7 @@ namespace Tests
             var initialPerson = Get.Person();
 
             var personJson = target.Serialize(initialPerson, DefaultUrl);
-            var dsPerson = target.Deserialize(personJson, typeof(Person));
+            var dsPerson = (Person)target.Deserialize(personJson, typeof(Person));
 
             Assert.Equal(initialPerson.FirstName, dsPerson.FirstName);
         }

--- a/Tests/JsonApiSerializerTests.cs
+++ b/Tests/JsonApiSerializerTests.cs
@@ -269,5 +269,17 @@ namespace Tests
 
             Assert.Equal("Attribute 'fail-me' not found.", error["title"].Value<string>());
         }
+
+        [Fact(DisplayName = "Deserialize")]
+        public void Gives()
+        {
+            var target = new JsonApiSerializer<PersonResource>();
+            var initialPerson = Get.Person();
+
+            var personJson = target.Serialize(initialPerson, DefaultUrl);
+            var dsPerson = target.Deserialize(personJson, typeof(Person));
+
+            Assert.Equal(initialPerson.FirstName, dsPerson.FirstName);
+        }
     }
 }


### PR DESCRIPTION
When testing APIs, it's super useful to be able to use `ResourceDeserializer` to deserialize json into specific objects.

We might for example receive a json string containing user data and nested data about the organization the user belongs to.

The json string can then be converted to a user object containing an organization object like this:

```
public T ConvertJson(string json) where T : class
{
	var jObject = JObject.Parse(json);
	var target = new ResourceDeserializer(jObject, typeof(T));
	return target.Deserialize() as T;
}
```