### PR TITLE
Do not serialize "data" on a relationship when the relationship value is null

### DIFF
--- a/Saule/ApiResource.cs
+++ b/Saule/ApiResource.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+
 using Humanizer;
 
 namespace Saule
@@ -175,7 +176,7 @@ namespace Saule
         protected ResourceRelationship BelongsTo<T>(string name, string path)
                     where T : ApiResource, new()
         {
-            return BelongsTo<T>(name, path, LinkType.All, false);
+            return BelongsTo<T>(name, path, LinkType.All);
         }
 
         /// <summary>
@@ -192,28 +193,10 @@ namespace Saule
         protected ResourceRelationship BelongsTo<T>(string name, string path, LinkType withLinks)
                     where T : ApiResource, new()
         {
-            return BelongsTo<T>(name, path, withLinks, false);
-        }
-
-        /// <summary>
-        /// Specify a to-one relationship of this resource.
-        /// </summary>
-        /// <typeparam name="T">The api resource type of the relationship.</typeparam>
-        /// <param name="name">The name of the relationship.</param>
-        /// <param name="path">The url pathspec of this relationship (default
-        /// is the name)</param>
-        /// <param name="withLinks">The defined <see cref="LinkType" /> to be generated for this relationship.</param>
-        /// <param name="excludeDataWhenNull">if set to <c>true</c> [exclude data when null].</param>
-        /// <returns>
-        /// The <see cref="ResourceRelationship" />.
-        /// </returns>
-        protected ResourceRelationship BelongsTo<T>(string name, string path, LinkType withLinks, bool excludeDataWhenNull)
-                    where T : ApiResource, new()
-        {
             VerifyPropertyName(name);
 
             var resource = GetUniqueResource<T>();
-            var result = new ResourceRelationship<T>(name, path, RelationshipKind.BelongsTo, resource, withLinks, excludeDataWhenNull);
+            var result = new ResourceRelationship<T>(name, path, RelationshipKind.BelongsTo, resource, withLinks);
 
             _relationships.Add(result);
 
@@ -242,7 +225,7 @@ namespace Saule
         protected ResourceRelationship HasMany<T>(string name, string path)
                     where T : ApiResource, new()
         {
-            return HasMany<T>(name, path, LinkType.All, false);
+            return HasMany<T>(name, path, LinkType.All);
         }
 
         /// <summary>
@@ -258,27 +241,10 @@ namespace Saule
         protected ResourceRelationship HasMany<T>(string name, string path, LinkType withLinks)
                     where T : ApiResource, new()
         {
-            return HasMany<T>(name, path, withLinks, false);
-        }
-
-        /// <summary>
-        /// Specify a to-many relationship of this resource.
-        /// </summary>
-        /// <typeparam name="T">The api resource type of the relationship.</typeparam>
-        /// <param name="name">The name of the relationship.</param>
-        /// <param name="path">The url pathspec of this relationship (default is the name).</param>
-        /// <param name="withLinks">The defined <see cref="LinkType" /> to be generated for this relationship.</param>
-        /// <param name="excludeDataWhenNull">if set to <c>true</c> [exclude data when null].</param>
-        /// <returns>
-        /// The <see cref="ResourceRelationship" />.
-        /// </returns>
-        protected ResourceRelationship HasMany<T>(string name, string path, LinkType withLinks, bool excludeDataWhenNull)
-                    where T : ApiResource, new()
-        {
             VerifyPropertyName(name);
 
             var resource = GetUniqueResource<T>();
-            var result = new ResourceRelationship<T>(name, path, RelationshipKind.HasMany, resource, withLinks, excludeDataWhenNull);
+            var result = new ResourceRelationship<T>(name, path, RelationshipKind.HasMany, resource, withLinks);
 
             _relationships.Add(result);
 

--- a/Saule/ApiResource.cs
+++ b/Saule/ApiResource.cs
@@ -175,25 +175,45 @@ namespace Saule
         protected ResourceRelationship BelongsTo<T>(string name, string path)
                     where T : ApiResource, new()
         {
-            return BelongsTo<T>(name, path, LinkType.All);
+            return BelongsTo<T>(name, path, LinkType.All, false);
         }
 
         /// <summary>
         /// Specify a to-one relationship of this resource.
         /// </summary>
+        /// <typeparam name="T">The api resource type of the relationship.</typeparam>
         /// <param name="name">The name of the relationship.</param>
         /// <param name="path">The url pathspec of this relationship (default
         /// is the name)</param>
-        /// <param name="withLinks">The defined <see cref="LinkType"/> to be generated for this relationship.</param>
-        /// <typeparam name="T">The api resource type of the relationship.</typeparam>
-        /// <returns>The <see cref="ResourceRelationship"/>.</returns>
+        /// <param name="withLinks">The defined <see cref="LinkType" /> to be generated for this relationship.</param>
+        /// <returns>
+        /// The <see cref="ResourceRelationship" />.
+        /// </returns>
         protected ResourceRelationship BelongsTo<T>(string name, string path, LinkType withLinks)
+                    where T : ApiResource, new()
+        {
+            return BelongsTo<T>(name, path, withLinks, false);
+        }
+
+        /// <summary>
+        /// Specify a to-one relationship of this resource.
+        /// </summary>
+        /// <typeparam name="T">The api resource type of the relationship.</typeparam>
+        /// <param name="name">The name of the relationship.</param>
+        /// <param name="path">The url pathspec of this relationship (default
+        /// is the name)</param>
+        /// <param name="withLinks">The defined <see cref="LinkType" /> to be generated for this relationship.</param>
+        /// <param name="excludeDataWhenNull">if set to <c>true</c> [exclude data when null].</param>
+        /// <returns>
+        /// The <see cref="ResourceRelationship" />.
+        /// </returns>
+        protected ResourceRelationship BelongsTo<T>(string name, string path, LinkType withLinks, bool excludeDataWhenNull)
                     where T : ApiResource, new()
         {
             VerifyPropertyName(name);
 
             var resource = GetUniqueResource<T>();
-            var result = new ResourceRelationship<T>(name, path, RelationshipKind.BelongsTo, resource, withLinks);
+            var result = new ResourceRelationship<T>(name, path, RelationshipKind.BelongsTo, resource, withLinks, excludeDataWhenNull);
 
             _relationships.Add(result);
 
@@ -222,24 +242,43 @@ namespace Saule
         protected ResourceRelationship HasMany<T>(string name, string path)
                     where T : ApiResource, new()
         {
-            return HasMany<T>(name, name, LinkType.All);
+            return HasMany<T>(name, path, LinkType.All, false);
         }
 
         /// <summary>
         /// Specify a to-many relationship of this resource.
         /// </summary>
+        /// <typeparam name="T">The api resource type of the relationship.</typeparam>
         /// <param name="name">The name of the relationship.</param>
         /// <param name="path">The url pathspec of this relationship (default is the name).</param>
-        /// <param name="withLinks">The defined <see cref="LinkType"/> to be generated for this relationship.</param>
-        /// <typeparam name="T">The api resource type of the relationship.</typeparam>
-        /// <returns>The <see cref="ResourceRelationship"/>.</returns>
+        /// <param name="withLinks">The defined <see cref="LinkType" /> to be generated for this relationship.</param>
+        /// <returns>
+        /// The <see cref="ResourceRelationship" />.
+        /// </returns>
         protected ResourceRelationship HasMany<T>(string name, string path, LinkType withLinks)
+                    where T : ApiResource, new()
+        {
+            return HasMany<T>(name, path, withLinks, false);
+        }
+
+        /// <summary>
+        /// Specify a to-many relationship of this resource.
+        /// </summary>
+        /// <typeparam name="T">The api resource type of the relationship.</typeparam>
+        /// <param name="name">The name of the relationship.</param>
+        /// <param name="path">The url pathspec of this relationship (default is the name).</param>
+        /// <param name="withLinks">The defined <see cref="LinkType" /> to be generated for this relationship.</param>
+        /// <param name="excludeDataWhenNull">if set to <c>true</c> [exclude data when null].</param>
+        /// <returns>
+        /// The <see cref="ResourceRelationship" />.
+        /// </returns>
+        protected ResourceRelationship HasMany<T>(string name, string path, LinkType withLinks, bool excludeDataWhenNull)
                     where T : ApiResource, new()
         {
             VerifyPropertyName(name);
 
             var resource = GetUniqueResource<T>();
-            var result = new ResourceRelationship<T>(name, path, RelationshipKind.HasMany, resource, withLinks);
+            var result = new ResourceRelationship<T>(name, path, RelationshipKind.HasMany, resource, withLinks, excludeDataWhenNull);
 
             _relationships.Add(result);
 

--- a/Saule/ResourceRelationship.cs
+++ b/Saule/ResourceRelationship.cs
@@ -6,22 +6,22 @@
     public abstract class ResourceRelationship
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ResourceRelationship"/> class.
+        /// Initializes a new instance of the <see cref="ResourceRelationship" /> class.
         /// </summary>
         /// <param name="name">The name of the reference on the resource that defines the relationship.</param>
-        /// <param name="urlPath">
-        /// The url path of this relationship relative to the resource url that holds
-        /// the relationship.
-        /// </param>
+        /// <param name="urlPath">The url path of this relationship relative to the resource url that holds
+        /// the relationship.</param>
         /// <param name="kind">The kind of relationship.</param>
         /// <param name="relationshipResource">The specification of the related resource.</param>
-        /// <param name="withLinks">The defined <see cref="LinkType"/> to be generated for this relationship.</param>
+        /// <param name="withLinks">The defined <see cref="LinkType" /> to be generated for this relationship.</param>
+        /// <param name="excludeDataWhenNull">if set to <c>true</c> [exclude when null].</param>
         protected ResourceRelationship(
             string name,
             string urlPath,
             RelationshipKind kind,
             ApiResource relationshipResource,
-            LinkType withLinks)
+            LinkType withLinks,
+            bool excludeDataWhenNull)
         {
             Name = name.ToDashed();
             PropertyName = name.ToPascalCase();
@@ -29,6 +29,7 @@
             RelatedResource = relationshipResource;
             Kind = kind;
             LinkType = withLinks;
+            ExcludeDataWhenNull = excludeDataWhenNull;
         }
 
         /// <summary>
@@ -60,6 +61,14 @@
         /// Gets the defined <see cref="LinkType"/> to be generated for this relationship.
         /// </summary>
         public LinkType LinkType { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether [exclude data when null].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [exclude data when null]; otherwise, <c>false</c>.
+        /// </value>
+        public bool ExcludeDataWhenNull { get; private set; }
 
         /// <inheritdoc />
         public override string ToString()

--- a/Saule/ResourceRelationship.cs
+++ b/Saule/ResourceRelationship.cs
@@ -14,14 +14,12 @@
         /// <param name="kind">The kind of relationship.</param>
         /// <param name="relationshipResource">The specification of the related resource.</param>
         /// <param name="withLinks">The defined <see cref="LinkType" /> to be generated for this relationship.</param>
-        /// <param name="excludeDataWhenNull">if set to <c>true</c> [exclude when null].</param>
         protected ResourceRelationship(
             string name,
             string urlPath,
             RelationshipKind kind,
             ApiResource relationshipResource,
-            LinkType withLinks,
-            bool excludeDataWhenNull)
+            LinkType withLinks)
         {
             Name = name.ToDashed();
             PropertyName = name.ToPascalCase();
@@ -29,7 +27,6 @@
             RelatedResource = relationshipResource;
             Kind = kind;
             LinkType = withLinks;
-            ExcludeDataWhenNull = excludeDataWhenNull;
         }
 
         /// <summary>
@@ -61,14 +58,6 @@
         /// Gets the defined <see cref="LinkType"/> to be generated for this relationship.
         /// </summary>
         public LinkType LinkType { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether [exclude data when null].
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if [exclude data when null]; otherwise, <c>false</c>.
-        /// </value>
-        public bool ExcludeDataWhenNull { get; private set; }
 
         /// <inheritdoc />
         public override string ToString()

--- a/Saule/ResourceRelationshipOfT.cs
+++ b/Saule/ResourceRelationshipOfT.cs
@@ -9,8 +9,8 @@ namespace Saule
     internal class ResourceRelationship<T> : ResourceRelationship
             where T : ApiResource, new()
         {
-        internal ResourceRelationship(string name, string urlPath, RelationshipKind kind, T resource, LinkType withLinks, bool excludeDataWhenNull)
-            : base(name, urlPath, kind, resource, withLinks, excludeDataWhenNull)
+        internal ResourceRelationship(string name, string urlPath, RelationshipKind kind, T resource, LinkType withLinks)
+            : base(name, urlPath, kind, resource, withLinks)
         {
         }
     }

--- a/Saule/ResourceRelationshipOfT.cs
+++ b/Saule/ResourceRelationshipOfT.cs
@@ -9,8 +9,8 @@ namespace Saule
     internal class ResourceRelationship<T> : ResourceRelationship
             where T : ApiResource, new()
         {
-        internal ResourceRelationship(string name, string urlPath, RelationshipKind kind, T resource, LinkType withLinks)
-            : base(name, urlPath, kind, resource, withLinks)
+        internal ResourceRelationship(string name, string urlPath, RelationshipKind kind, T resource, LinkType withLinks, bool excludeDataWhenNull)
+            : base(name, urlPath, kind, resource, withLinks, excludeDataWhenNull)
         {
         }
     }

--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -323,7 +323,7 @@ namespace Saule.Serialization
                     item["links"] = links;
                 }
 
-                if (data != null)
+                if (data != null && kv.Value != null && kv.Value.SourceObject != null)
                 {
                     item["data"] = data;
                 }

--- a/Tests/JsonApiSerializerTests.cs
+++ b/Tests/JsonApiSerializerTests.cs
@@ -68,6 +68,21 @@ namespace Tests
 
         }
 
+        [Fact(DisplayName = "Does not include relationship data when the relationship is null")]
+        public void DoesNotIncludeNullData()
+        {
+            var target = new JsonApiSerializer<PersonResource>();
+            var model = new Person()
+            {
+                Identifier = "Id",
+                Job = null
+            };
+
+            var result = target.Serialize(model, new System.Uri("http://somewhere.com"));
+
+             Assert.Null(result["data"]["relationships"]["job"]["data"]);
+        }
+
         [Fact(DisplayName = "Does not allow null Uri")]
         public void HasAContract()
         {

--- a/Tests/JsonApiSerializerTests.cs
+++ b/Tests/JsonApiSerializerTests.cs
@@ -78,7 +78,7 @@ namespace Tests
                 Job = null
             };
 
-            var result = target.Serialize(model, new System.Uri("http://somewhere.com"));
+            var result = target.Serialize(model, DefaultUrl);
 
              Assert.Null(result["data"]["relationships"]["job"]["data"]);
         }

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -143,6 +143,8 @@ namespace Tests.Serialization
                 }
             };
 
+            person.Job = null;
+
             var target = new ResourceSerializer(person, DefaultResource,
                 GetUri(id: "abc"), DefaultPathBuilder, null, null);
 
@@ -392,8 +394,8 @@ namespace Tests.Serialization
             Assert.NotNull(attributes["last-name"]);
             Assert.NotNull(attributes["age"]);
 
-            Assert.Equal(0, relationships["job"]["data"].Count());
-            Assert.Equal(0, relationships["friends"]["data"].Count());
+            Assert.Null(relationships["job"]["data"]);
+            Assert.Null(relationships["friends"]["data"]);
         }
 
         [Fact(DisplayName = "Serializes enumerables properly")]

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -143,8 +143,6 @@ namespace Tests.Serialization
                 }
             };
 
-            person.Job = null;
-
             var target = new ResourceSerializer(person, DefaultResource,
                 GetUri(id: "abc"), DefaultPathBuilder, null, null);
 


### PR DESCRIPTION
Hey man,

love this library it is awesome. 

Just wanted to submit a potential change. To not serialize the "data" on a relationship when that relationship was null. Just referring to this part of the standard (http://jsonapi.org/format/#document-resource-object-relationships) "A “relationship object” MUST contain at least one of the following:".

Cheers
Trent