### PR TITLE
Provide ability to handle JsonApi parameters in WebApi action itself manually

### DIFF
--- a/Saule/Http/AllowsManuallyHandledQueryAttribute.cs
+++ b/Saule/Http/AllowsManuallyHandledQueryAttribute.cs
@@ -1,0 +1,54 @@
+﻿using System.Linq;
+using System.Net.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using Saule.Queries;
+using Saule.Queries.Filtering;
+using Saule.Queries.Including;
+using Saule.Queries.Sorting;
+
+namespace Saule.Http
+{
+    /// <summary>
+    /// Indicates that filter, paging, include and sorting should be parsed. But they won't be automatically applied to WebApi action, 
+    /// and action should handle them manually
+    /// </summary>
+    public class AllowsManuallyHandledQueryAttribute : ActionFilterAttribute
+    {
+        /// <summary>
+        /// See base class documentation.
+        /// </summary>
+        /// <param name="actionContext">The action context.</param>
+        public override void OnActionExecuting(HttpActionContext actionContext)
+        {
+            var queryParams = actionContext.Request.GetQueryNameValuePairs().ToList();
+            var queryContext = QueryContextUtils.GetQueryContext(actionContext);
+
+            queryContext.IsManuallyHandledQuery = true;
+            queryContext.Sorting = new SortingContext(queryParams);
+            queryContext.Filtering = new FilteringContext(queryParams);
+
+            if (queryContext.Including == null)
+            {
+                queryContext.Including = new IncludingContext(queryParams);
+            }
+            else
+            {
+                queryContext.Including.SetIncludes(queryParams);
+            }
+
+            // we validate if action has QueryContext parameter
+            // and if it has it, then we pass it
+            var parameters = actionContext.ActionDescriptor.GetParameters();
+            foreach (var parameter in parameters)
+            {
+                if (parameter.ParameterType == typeof(QueryContext))
+                {
+                    actionContext.ActionArguments[parameter.ParameterName] = queryContext;
+                }
+            }
+
+            base.OnActionExecuting(actionContext);
+        }
+    }
+}

--- a/Saule/Http/AllowsManuallyHandledQueryAttribute.cs
+++ b/Saule/Http/AllowsManuallyHandledQueryAttribute.cs
@@ -10,7 +10,7 @@ using Saule.Queries.Sorting;
 namespace Saule.Http
 {
     /// <summary>
-    /// Indicates that filter, paging, include and sorting should be parsed. But they won't be automatically applied to WebApi action, 
+    /// Indicates that filter, paging, include and sorting should be parsed. But they won't be automatically applied to WebApi action
     /// and action should handle them manually
     /// </summary>
     public class AllowsManuallyHandledQueryAttribute : ActionFilterAttribute

--- a/Saule/Http/AllowsQueryAttribute.cs
+++ b/Saule/Http/AllowsQueryAttribute.cs
@@ -26,16 +26,16 @@ namespace Saule.Http
             var queryParams = actionContext.Request.GetQueryNameValuePairs().ToList();
             var queryContext = QueryContextUtils.GetQueryContext(actionContext);
 
-            queryContext.Sorting = new SortingContext(queryParams);
-            queryContext.Filtering = new FilteringContext(queryParams);
+            queryContext.Sort = new SortContext(queryParams);
+            queryContext.Filter = new FilterContext(queryParams);
 
-            if (queryContext.Including == null)
+            if (queryContext.Include == null)
             {
-                queryContext.Including = new IncludingContext(queryParams);
+                queryContext.Include = new IncludeContext(queryParams);
             }
             else
             {
-                queryContext.Including.SetIncludes(queryParams);
+                queryContext.Include.SetIncludes(queryParams);
             }
 
             base.OnActionExecuting(actionContext);

--- a/Saule/Http/DisableDefaultIncludedAttribute.cs
+++ b/Saule/Http/DisableDefaultIncludedAttribute.cs
@@ -22,12 +22,12 @@ namespace Saule.Http
         {
             var queryContext = QueryContextUtils.GetQueryContext(actionContext);
 
-            if (queryContext.Including == null)
+            if (queryContext.Include == null)
             {
-                queryContext.Including = new IncludingContext();
+                queryContext.Include = new IncludeContext();
             }
 
-            queryContext.Including.DisableDefaultIncluded = true;
+            queryContext.Include.DisableDefaultIncluded = true;
 
             base.OnActionExecuting(actionContext);
         }

--- a/Saule/Http/HttpConfigExtensions.cs
+++ b/Saule/Http/HttpConfigExtensions.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Formatting;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
+using System.Web.Http.ValueProviders;
 using Saule.Queries;
 using Saule.Serialization;
 
@@ -70,6 +71,9 @@ namespace Saule.Http
           FormatterPriority formatterPriority)
         {
             config.MessageHandlers.Add(new PreprocessingDelegatingHandler(jsonApiConfiguration));
+
+            config.Services.Add(typeof(ValueProviderFactory), new JsonApiQueryValueProviderFactory());
+
             var formatter = new JsonApiMediaTypeFormatter(jsonApiConfiguration);
 
             if (formatterPriority == FormatterPriority.OverwriteOtherFormatters)

--- a/Saule/Http/JsonApiQueryValueProvider.cs
+++ b/Saule/Http/JsonApiQueryValueProvider.cs
@@ -15,6 +15,8 @@ namespace Saule.Http
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonApiQueryValueProvider"/> class.
         /// </summary>
+        /// <param name="actionContext">current ActionContext</param>
+        /// <param name="culture">target culture</param>
         public JsonApiQueryValueProvider(HttpActionContext actionContext, CultureInfo culture)
             : base(() => ParseSauleQueryPairs(actionContext), culture)
         {

--- a/Saule/Http/JsonApiQueryValueProvider.cs
+++ b/Saule/Http/JsonApiQueryValueProvider.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.ValueProviders.Providers;
+
+namespace Saule.Http
+{
+    /// <summary>
+    /// Provider that will convert json api filters from kebab case to pascal case, so WebApi model binder would be able to parse it
+    /// </summary>
+    public class JsonApiQueryValueProvider : NameValuePairsValueProvider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonApiQueryValueProvider"/> class.
+        /// </summary>
+        public JsonApiQueryValueProvider(HttpActionContext actionContext, CultureInfo culture)
+            : base(() => ParseSauleQueryPairs(actionContext), culture)
+        {
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> ParseSauleQueryPairs(HttpActionContext actionContext)
+        {
+            // convert key to pascal case
+            return actionContext.ControllerContext.Request.GetQueryNameValuePairs()
+                .Select(p => new KeyValuePair<string, string>(p.Key.ToPascalCase(), p.Value))
+                .ToList();
+        }
+    }
+}

--- a/Saule/Http/JsonApiQueryValueProviderFactory.cs
+++ b/Saule/Http/JsonApiQueryValueProviderFactory.cs
@@ -1,0 +1,17 @@
+﻿using System.Globalization;
+using System.Web.Http.Controllers;
+using System.Web.Http.ValueProviders;
+
+namespace Saule.Http
+{
+    /// <summary>
+    /// Value provider factory for JsonApiQueryValueProvider
+    /// </summary>
+    public class JsonApiQueryValueProviderFactory : ValueProviderFactory, IUriValueProviderFactory
+    {
+        public override IValueProvider GetValueProvider(HttpActionContext actionContext)
+        {
+            return new JsonApiQueryValueProvider(actionContext, CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/Saule/Http/JsonApiQueryValueProviderFactory.cs
+++ b/Saule/Http/JsonApiQueryValueProviderFactory.cs
@@ -9,6 +9,7 @@ namespace Saule.Http
     /// </summary>
     public class JsonApiQueryValueProviderFactory : ValueProviderFactory, IUriValueProviderFactory
     {
+        /// <inheritdoc/>
         public override IValueProvider GetValueProvider(HttpActionContext actionContext)
         {
             return new JsonApiQueryValueProvider(actionContext, CultureInfo.InvariantCulture);

--- a/Saule/Http/PreprocessingDelegatingHandler.cs
+++ b/Saule/Http/PreprocessingDelegatingHandler.cs
@@ -131,9 +131,9 @@ namespace Saule.Http
 
             var queryContext = (QueryContext)request.Properties[Constants.PropertyNames.QueryContext];
 
-            if (queryContext.Filtering != null)
+            if (queryContext.Filter != null)
             {
-                queryContext.Filtering.QueryFilters = config.QueryFilterExpressions;
+                queryContext.Filter.QueryFilters = config.QueryFilterExpressions;
             }
 
             jsonApiSerializer.QueryContext = queryContext;

--- a/Saule/JsonApiSerializer.cs
+++ b/Saule/JsonApiSerializer.cs
@@ -53,19 +53,22 @@ namespace Saule
 
                 var dataObject = @object;
 
-                if (QueryContext?.Filtering != null)
+                if (QueryContext != null && !QueryContext.IsManuallyHandledQuery)
                 {
-                    dataObject = Query.ApplyFiltering(dataObject, QueryContext.Filtering, resource);
-                }
+                    if (QueryContext.Filtering != null)
+                    {
+                        dataObject = Query.ApplyFiltering(dataObject, QueryContext.Filtering, resource);
+                    }
 
-                if (QueryContext?.Sorting != null)
-                {
-                    dataObject = Query.ApplySorting(dataObject, QueryContext.Sorting, resource);
-                }
+                    if (QueryContext.Sorting != null)
+                    {
+                        dataObject = Query.ApplySorting(dataObject, QueryContext.Sorting, resource);
+                    }
 
-                if (QueryContext?.Pagination != null)
-                {
-                    dataObject = Query.ApplyPagination(dataObject, QueryContext.Pagination, resource);
+                    if (QueryContext.Pagination != null)
+                    {
+                        dataObject = Query.ApplyPagination(dataObject, QueryContext.Pagination, resource);
+                    }
                 }
 
                 result.ResourceSerializer = new ResourceSerializer(

--- a/Saule/JsonApiSerializer.cs
+++ b/Saule/JsonApiSerializer.cs
@@ -53,16 +53,16 @@ namespace Saule
 
                 var dataObject = @object;
 
-                if (QueryContext != null && !QueryContext.IsManuallyHandledQuery)
+                if (QueryContext != null && !QueryContext.IsHandledQuery)
                 {
-                    if (QueryContext.Filtering != null)
+                    if (QueryContext.Filter != null)
                     {
-                        dataObject = Query.ApplyFiltering(dataObject, QueryContext.Filtering, resource);
+                        dataObject = Query.ApplyFiltering(dataObject, QueryContext.Filter, resource);
                     }
 
-                    if (QueryContext.Sorting != null)
+                    if (QueryContext.Sort != null)
                     {
-                        dataObject = Query.ApplySorting(dataObject, QueryContext.Sorting, resource);
+                        dataObject = Query.ApplySorting(dataObject, QueryContext.Sort, resource);
                     }
 
                     if (QueryContext.Pagination != null)
@@ -77,7 +77,7 @@ namespace Saule
                         baseUrl: requestUri,
                         urlBuilder: UrlPathBuilder,
                         paginationContext: QueryContext?.Pagination,
-                        includingContext: QueryContext?.Including);
+                        includeContext: QueryContext?.Include);
             }
             catch (Exception ex)
             {

--- a/Saule/JsonApiSerializerOfT.cs
+++ b/Saule/JsonApiSerializerOfT.cs
@@ -115,9 +115,9 @@ namespace Saule
 
             if (AllowQuery)
             {
-                context.Sorting = new SortingContext(keyValuePairs);
-                context.Filtering = new FilteringContext(keyValuePairs) { QueryFilters = QueryFilterExpressions };
-                context.Including = new IncludingContext(keyValuePairs);
+                context.Sort = new SortContext(keyValuePairs);
+                context.Filter = new FilterContext(keyValuePairs) { QueryFilters = QueryFilterExpressions };
+                context.Include = new IncludeContext(keyValuePairs);
             }
 
             return context;

--- a/Saule/Queries/Filtering/FilterContext.cs
+++ b/Saule/Queries/Filtering/FilterContext.cs
@@ -7,26 +7,26 @@ namespace Saule.Queries.Filtering
     /// <summary>
     /// Context for filtering operations
     /// </summary>
-    public class FilteringContext
+    public class FilterContext
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FilteringContext"/> class.
+        /// Initializes a new instance of the <see cref="FilterContext"/> class.
         /// </summary>
         /// <param name="queryParams">query string that might contain Filter keyword</param>
-        public FilteringContext(IEnumerable<KeyValuePair<string, string>> queryParams)
+        public FilterContext(IEnumerable<KeyValuePair<string, string>> queryParams)
         {
             Properties =
                 from query in queryParams
                 where query.Key.StartsWith(Constants.QueryNames.Filtering)
                 let name = query.Key.Substring(Constants.QueryNames.Filtering.Length + 1)
                 let value = query.Value
-                select new FilteringProperty(name, value);
+                select new FilterProperty(name, value);
         }
 
         /// <summary>
         /// Gets filtering properties
         /// </summary>
-        public IEnumerable<FilteringProperty> Properties { get; }
+        public IEnumerable<FilterProperty> Properties { get; }
 
         /// <summary>
         /// Gets custom query filters

--- a/Saule/Queries/Filtering/FilterInterpreter.cs
+++ b/Saule/Queries/Filtering/FilterInterpreter.cs
@@ -5,12 +5,12 @@ using Saule.Http;
 
 namespace Saule.Queries.Filtering
 {
-    internal class FilteringInterpreter
+    internal class FilterInterpreter
     {
-        private readonly FilteringContext _context;
+        private readonly FilterContext _context;
         private readonly ApiResource _resource;
 
-        public FilteringInterpreter(FilteringContext context, ApiResource resource)
+        public FilterInterpreter(FilterContext context, ApiResource resource)
         {
             _context = context;
             _resource = resource;
@@ -21,7 +21,7 @@ namespace Saule.Queries.Filtering
             if (_context.Properties.Any())
             {
                  return _context.Properties
-                    .Select(p => p.Name == "Id" ? new FilteringProperty(_resource.IdProperty, p.Value) : p)
+                    .Select(p => p.Name == "Id" ? new FilterProperty(_resource.IdProperty, p.Value) : p)
                     .Aggregate(queryable, ApplyProperty);
             }
 
@@ -33,7 +33,7 @@ namespace Saule.Queries.Filtering
             if (_context.Properties.Any())
             {
                  return _context.Properties
-                    .Select(p => p.Name == "Id" ? new FilteringProperty(_resource.IdProperty, p.Value) : p)
+                    .Select(p => p.Name == "Id" ? new FilterProperty(_resource.IdProperty, p.Value) : p)
                     .Aggregate(enumerable, ApplyProperty);
             }
 
@@ -45,7 +45,7 @@ namespace Saule.Queries.Filtering
             return new JsonApiException(ErrorType.Client, $"Attribute '{property.ToDashed()}' not found.", ex);
         }
 
-        private IEnumerable ApplyProperty(IEnumerable enumerable, FilteringProperty property)
+        private IEnumerable ApplyProperty(IEnumerable enumerable, FilterProperty property)
         {
             try
             {
@@ -68,7 +68,7 @@ namespace Saule.Queries.Filtering
             }
         }
 
-        private IQueryable ApplyProperty(IQueryable queryable, FilteringProperty property)
+        private IQueryable ApplyProperty(IQueryable queryable, FilterProperty property)
         {
             try
             {

--- a/Saule/Queries/Filtering/FilterProperty.cs
+++ b/Saule/Queries/Filtering/FilterProperty.cs
@@ -3,14 +3,14 @@
     /// <summary>
     /// Property for filtering
     /// </summary>
-    public class FilteringProperty
+    public class FilterProperty
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FilteringProperty"/> class.
+        /// Initializes a new instance of the <see cref="FilterProperty"/> class.
         /// </summary>
         /// <param name="name">property name</param>
         /// <param name="value">property value</param>
-        public FilteringProperty(string name, string value)
+        public FilterProperty(string name, string value)
         {
             Value = value;
             Name = name.ToPascalCase();

--- a/Saule/Queries/Filtering/FilteringContext.cs
+++ b/Saule/Queries/Filtering/FilteringContext.cs
@@ -4,7 +4,7 @@ using Saule.Http;
 
 namespace Saule.Queries.Filtering
 {
-    internal class FilteringContext
+    public class FilteringContext
     {
         public FilteringContext(IEnumerable<KeyValuePair<string, string>> queryParams)
         {
@@ -18,7 +18,20 @@ namespace Saule.Queries.Filtering
 
         public IEnumerable<FilteringProperty> Properties { get; }
 
-        public QueryFilterExpressionCollection QueryFilters { get; set; } = new QueryFilterExpressionCollection();
+        public QueryFilterExpressionCollection QueryFilters { get; internal set; } = new QueryFilterExpressionCollection();
+
+        public bool TryGetValue<T>(string name, out T value)
+        {
+            var property = Properties.FirstOrDefault(p => p.Name == name);
+            if (property == null)
+            {
+                value = default(T);
+                return false;
+            }
+
+            value = (T)Lambda.TryConvert(property.Value, typeof(T));
+            return true;
+        }
 
         public override string ToString()
         {

--- a/Saule/Queries/Filtering/FilteringContext.cs
+++ b/Saule/Queries/Filtering/FilteringContext.cs
@@ -4,8 +4,15 @@ using Saule.Http;
 
 namespace Saule.Queries.Filtering
 {
+    /// <summary>
+    /// Context for filtering operations
+    /// </summary>
     public class FilteringContext
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilteringContext"/> class.
+        /// </summary>
+        /// <param name="queryParams">query string that might contain Filter keyword</param>
         public FilteringContext(IEnumerable<KeyValuePair<string, string>> queryParams)
         {
             Properties =
@@ -16,10 +23,23 @@ namespace Saule.Queries.Filtering
                 select new FilteringProperty(name, value);
         }
 
+        /// <summary>
+        /// Gets filtering properties
+        /// </summary>
         public IEnumerable<FilteringProperty> Properties { get; }
 
+        /// <summary>
+        /// Gets custom query filters
+        /// </summary>
         public QueryFilterExpressionCollection QueryFilters { get; internal set; } = new QueryFilterExpressionCollection();
 
+        /// <summary>
+        /// checking that specified property exists and returns converted value for it
+        /// </summary>
+        /// <typeparam name="T">Type of property</typeparam>
+        /// <param name="name">property name</param>
+        /// <param name="value">property value</param>
+        /// <returns>true if property is specified. Otherwise false</returns>
         public bool TryGetValue<T>(string name, out T value)
         {
             var property = Properties.FirstOrDefault(p => p.Name == name);
@@ -33,6 +53,7 @@ namespace Saule.Queries.Filtering
             return true;
         }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Join("&", Properties.Select(p => p.ToString()));

--- a/Saule/Queries/Filtering/FilteringProperty.cs
+++ b/Saule/Queries/Filtering/FilteringProperty.cs
@@ -1,6 +1,6 @@
 ﻿namespace Saule.Queries.Filtering
 {
-    internal class FilteringProperty
+    public class FilteringProperty
     {
         public FilteringProperty(string name, string value)
         {

--- a/Saule/Queries/Filtering/FilteringProperty.cs
+++ b/Saule/Queries/Filtering/FilteringProperty.cs
@@ -1,17 +1,32 @@
 ﻿namespace Saule.Queries.Filtering
 {
+    /// <summary>
+    /// Property for filtering
+    /// </summary>
     public class FilteringProperty
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilteringProperty"/> class.
+        /// </summary>
+        /// <param name="name">property name</param>
+        /// <param name="value">property value</param>
         public FilteringProperty(string name, string value)
         {
             Value = value;
             Name = name.ToPascalCase();
         }
 
+        /// <summary>
+        /// Gets property name
+        /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// Gets property value
+        /// </summary>
         public string Value { get; }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return $"filter[{Name}]={Value}";

--- a/Saule/Queries/Including/IncludeContext.cs
+++ b/Saule/Queries/Including/IncludeContext.cs
@@ -6,21 +6,21 @@ namespace Saule.Queries.Including
     /// <summary>
     /// Context for including operations
     /// </summary>
-    public class IncludingContext
+    public class IncludeContext
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="IncludingContext"/> class.
+        /// Initializes a new instance of the <see cref="IncludeContext"/> class.
         /// </summary>
-        public IncludingContext()
+        public IncludeContext()
         {
             DisableDefaultIncluded = false;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="IncludingContext"/> class.
+        /// Initializes a new instance of the <see cref="IncludeContext"/> class.
         /// </summary>
         /// <param name="includes">query string that might contain Include keyword</param>
-        public IncludingContext(IEnumerable<KeyValuePair<string, string>> includes)
+        public IncludeContext(IEnumerable<KeyValuePair<string, string>> includes)
             : this()
         {
             SetIncludes(includes);
@@ -29,7 +29,7 @@ namespace Saule.Queries.Including
         /// <summary>
         /// Gets including properties
         /// </summary>
-        public IEnumerable<IncludingProperty> Includes { get; internal set; }
+        public IEnumerable<IncludeProperty> Includes { get; internal set; }
 
         /// <summary>
         /// Gets a value indicating whether includes shouldn't be returned by default or not
@@ -48,11 +48,11 @@ namespace Saule.Queries.Including
             if (dict.ContainsKey(Constants.QueryNames.Including))
             {
                 var relatedResources = dict[Constants.QueryNames.Including].Split(',').Select(s => s.Trim());
-                Includes = relatedResources.Select(x => new IncludingProperty(x));
+                Includes = relatedResources.Select(x => new IncludeProperty(x));
             }
             else
             {
-                Includes = new IncludingProperty[0];
+                Includes = new IncludeProperty[0];
             }
         }
     }

--- a/Saule/Queries/Including/IncludeProperty.cs
+++ b/Saule/Queries/Including/IncludeProperty.cs
@@ -3,13 +3,13 @@
     /// <summary>
     /// Property for including
     /// </summary>
-    public class IncludingProperty
+    public class IncludeProperty
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="IncludingProperty"/> class.
+        /// Initializes a new instance of the <see cref="IncludeProperty"/> class.
         /// </summary>
         /// <param name="name">property name</param>
-        public IncludingProperty(string name)
+        public IncludeProperty(string name)
         {
             Name = name.ToPascalCase();
         }

--- a/Saule/Queries/Including/IncludingContext.cs
+++ b/Saule/Queries/Including/IncludingContext.cs
@@ -3,23 +3,40 @@ using System.Linq;
 
 namespace Saule.Queries.Including
 {
+    /// <summary>
+    /// Context for including operations
+    /// </summary>
     public class IncludingContext
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IncludingContext"/> class.
+        /// </summary>
         public IncludingContext()
         {
             DisableDefaultIncluded = false;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IncludingContext"/> class.
+        /// </summary>
+        /// <param name="includes">query string that might contain Include keyword</param>
         public IncludingContext(IEnumerable<KeyValuePair<string, string>> includes)
             : this()
         {
             SetIncludes(includes);
         }
 
+        /// <summary>
+        /// Gets including properties
+        /// </summary>
         public IEnumerable<IncludingProperty> Includes { get; internal set; }
 
+        /// <summary>
+        /// Gets a value indicating whether includes shouldn't be returned by default or not
+        /// </summary>
         public bool DisableDefaultIncluded { get; internal set; }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return Includes != null && Includes.Any() ? "include=" + string.Join(",", Includes.Select(p => p.ToString())) : string.Empty;

--- a/Saule/Queries/Including/IncludingContext.cs
+++ b/Saule/Queries/Including/IncludingContext.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Saule.Queries.Including
 {
-    internal class IncludingContext
+    public class IncludingContext
     {
         public IncludingContext()
         {
@@ -16,11 +16,16 @@ namespace Saule.Queries.Including
             SetIncludes(includes);
         }
 
-        public IEnumerable<IncludingProperty> Includes { get; set; }
+        public IEnumerable<IncludingProperty> Includes { get; internal set; }
 
-        public bool DisableDefaultIncluded { get; set; }
+        public bool DisableDefaultIncluded { get; internal set; }
 
-        public void SetIncludes(IEnumerable<KeyValuePair<string, string>> includes)
+        public override string ToString()
+        {
+            return Includes != null && Includes.Any() ? "include=" + string.Join(",", Includes.Select(p => p.ToString())) : string.Empty;
+        }
+
+        internal void SetIncludes(IEnumerable<KeyValuePair<string, string>> includes)
         {
             var dict = includes.ToDictionary(kv => kv.Key, kv => kv.Value);
             if (dict.ContainsKey(Constants.QueryNames.Including))
@@ -32,11 +37,6 @@ namespace Saule.Queries.Including
             {
                 Includes = new IncludingProperty[0];
             }
-        }
-
-        public override string ToString()
-        {
-            return Includes != null && Includes.Any() ? "include=" + string.Join(",", Includes.Select(p => p.ToString())) : string.Empty;
         }
     }
 }

--- a/Saule/Queries/Including/IncludingProperty.cs
+++ b/Saule/Queries/Including/IncludingProperty.cs
@@ -1,14 +1,25 @@
 ﻿namespace Saule.Queries.Including
 {
+    /// <summary>
+    /// Property for including
+    /// </summary>
     public class IncludingProperty
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IncludingProperty"/> class.
+        /// </summary>
+        /// <param name="name">property name</param>
         public IncludingProperty(string name)
         {
             Name = name.ToPascalCase();
         }
 
+        /// <summary>
+        /// Gets property name
+        /// </summary>
         public string Name { get; }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return Name;

--- a/Saule/Queries/Including/IncludingProperty.cs
+++ b/Saule/Queries/Including/IncludingProperty.cs
@@ -1,6 +1,6 @@
 ﻿namespace Saule.Queries.Including
 {
-    internal class IncludingProperty
+    public class IncludingProperty
     {
         public IncludingProperty(string name)
         {

--- a/Saule/Queries/Lambda.cs
+++ b/Saule/Queries/Lambda.cs
@@ -37,6 +37,12 @@ namespace Saule.Queries
             return expressionFactory.Invoke(null, new object[] { propertyExpression, new[] { param } }) as Expression;
         }
 
+        internal static object TryConvert(string value, Type type)
+        {
+            var converter = TypeDescriptor.GetConverter(type);
+            return converter.ConvertFromInvariantString(value);
+        }
+
         // Return value is used through reflection invocation
         // ReSharper disable once UnusedMethodReturnValue.Local
         private static Expression<Func<TClass, bool>> Convert<TProperty, TClass>(
@@ -47,12 +53,6 @@ namespace Saule.Queries
         {
             var curriedBody = new FilterLambdaVisitor<TProperty>(propertyExpression, constant).Visit(expression.Body);
             return Expression.Lambda<Func<TClass, bool>>(curriedBody, parameter);
-        }
-
-        internal static object TryConvert(string value, Type type)
-        {
-            var converter = TypeDescriptor.GetConverter(type);
-            return converter.ConvertFromInvariantString(value);
         }
 
         private static Type GetPropertyType(Type type, string property)

--- a/Saule/Queries/Lambda.cs
+++ b/Saule/Queries/Lambda.cs
@@ -49,7 +49,7 @@ namespace Saule.Queries
             return Expression.Lambda<Func<TClass, bool>>(curriedBody, parameter);
         }
 
-        private static object TryConvert(string value, Type type)
+        internal static object TryConvert(string value, Type type)
         {
             var converter = TypeDescriptor.GetConverter(type);
             return converter.ConvertFromInvariantString(value);

--- a/Saule/Queries/Pagination/PaginationContext.cs
+++ b/Saule/Queries/Pagination/PaginationContext.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Saule.Queries.Pagination
 {
-    internal class PaginationContext
+    public class PaginationContext
     {
         public PaginationContext(IEnumerable<KeyValuePair<string, string>> filters, int? pageSizeDefault)
             : this(filters, pageSizeDefault, null)
@@ -23,9 +23,9 @@ namespace Saule.Queries.Pagination
 
         public int Page { get; }
 
-        public int? PerPage { get; set; }
+        public int? PerPage { get; internal set; }
 
-        public int? PageSizeLimit { get; set; }
+        public int? PageSizeLimit { get; internal set; }
 
         public IDictionary<string, string> ClientFilters { get; }
 

--- a/Saule/Queries/Pagination/PaginationContext.cs
+++ b/Saule/Queries/Pagination/PaginationContext.cs
@@ -3,13 +3,27 @@ using System.Linq;
 
 namespace Saule.Queries.Pagination
 {
+    /// <summary>
+    /// Context for pagination
+    /// </summary>
     public class PaginationContext
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PaginationContext"/> class.
+        /// </summary>
+        /// <param name="filters">query string that might contain Page keyword</param>
+        /// <param name="pageSizeDefault">default page size</param>
         public PaginationContext(IEnumerable<KeyValuePair<string, string>> filters, int? pageSizeDefault)
             : this(filters, pageSizeDefault, null)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PaginationContext"/> class.
+        /// </summary>
+        /// <param name="filters">query string that might contain Page keyword</param>
+        /// <param name="pageSizeDefault">default page size</param>
+        /// <param name="pageSizeLimit">maximum page size</param>
         public PaginationContext(IEnumerable<KeyValuePair<string, string>> filters, int? pageSizeDefault, int? pageSizeLimit)
         {
             var keyValuePairs = filters as IList<KeyValuePair<string, string>> ?? filters.ToList();
@@ -21,14 +35,27 @@ namespace Saule.Queries.Pagination
             PageSizeLimit = pageSizeLimit;
         }
 
+        /// <summary>
+        /// Gets page number
+        /// </summary>
         public int Page { get; }
 
+        /// <summary>
+        /// Gets page size
+        /// </summary>
         public int? PerPage { get; internal set; }
 
+        /// <summary>
+        /// Gets maximum page size
+        /// </summary>
         public int? PageSizeLimit { get; internal set; }
 
+        /// <summary>
+        /// Gets client filters
+        /// </summary>
         public IDictionary<string, string> ClientFilters { get; }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             string pageNum = $"page[number]={Page}";

--- a/Saule/Queries/Query.cs
+++ b/Saule/Queries/Query.cs
@@ -9,12 +9,12 @@ namespace Saule.Queries
 {
     internal static class Query
     {
-        public static object ApplySorting(object data, SortingContext context, ApiResource resource)
+        public static object ApplySorting(object data, SortContext context, ApiResource resource)
         {
             var queryable = data as IQueryable;
             if (queryable != null)
             {
-                return new SortingInterpreter(context, resource).Apply(queryable);
+                return new SortInterpreter(context, resource).Apply(queryable);
             }
 
             var enumerable = data as IEnumerable;
@@ -22,7 +22,7 @@ namespace Saule.Queries
             {
                 // all queryables are enumerable, so this needs to be after
                 // the queryable case
-                return new SortingInterpreter(context, resource).Apply(enumerable);
+                return new SortInterpreter(context, resource).Apply(enumerable);
             }
 
             return data;
@@ -47,12 +47,12 @@ namespace Saule.Queries
             return data;
         }
 
-        public static object ApplyFiltering(object data, FilteringContext context, ApiResource resource)
+        public static object ApplyFiltering(object data, FilterContext context, ApiResource resource)
         {
             var queryable = data as IQueryable;
             if (queryable != null)
             {
-                return new FilteringInterpreter(context, resource).Apply(queryable);
+                return new FilterInterpreter(context, resource).Apply(queryable);
             }
 
             var enumerable = data as IEnumerable;
@@ -60,7 +60,7 @@ namespace Saule.Queries
             {
                 // all queryables are enumerable, so this needs to be after
                 // the queryable case
-                return new FilteringInterpreter(context, resource).Apply(enumerable);
+                return new FilterInterpreter(context, resource).Apply(enumerable);
             }
 
             return data;

--- a/Saule/Queries/QueryContext.cs
+++ b/Saule/Queries/QueryContext.cs
@@ -19,25 +19,25 @@ namespace Saule.Queries
         public PaginationContext Pagination { get; internal set; }
 
         /// <summary>
-        /// Gets sorting context
+        /// Gets sort context
         /// </summary>
-        public SortingContext Sorting { get; internal set; }
+        public SortContext Sort { get; internal set; }
 
         /// <summary>
-        /// Gets filtering context
+        /// Gets filter context
         /// </summary>
-        public FilteringContext Filtering { get; internal set; }
+        public FilterContext Filter { get; internal set; }
 
         /// <summary>
-        /// Gets including context
+        /// Gets include context
         /// </summary>
-        public IncludingContext Including { get; internal set; }
+        public IncludeContext Include { get; internal set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether that query parameters
         /// will be handled by action itself or Saule should handle them
         /// </summary>
-        internal bool IsManuallyHandledQuery { get; set; }
+        internal bool IsHandledQuery { get; set; }
 
         /// <inheritdoc/>
         public override string ToString()
@@ -45,9 +45,9 @@ namespace Saule.Queries
             var result = new List<string>
             {
                 Pagination?.ToString(),
-                Sorting?.ToString(),
-                Filtering?.ToString(),
-                Including?.ToString()
+                Sort?.ToString(),
+                Filter?.ToString(),
+                Include?.ToString()
             };
 
             return string.Join("&", result.Where(c => !string.IsNullOrEmpty(c)));

--- a/Saule/Queries/QueryContext.cs
+++ b/Saule/Queries/QueryContext.cs
@@ -8,15 +8,21 @@ using Saule.Queries.Sorting;
 
 namespace Saule.Queries
 {
-    internal class QueryContext
+    public class QueryContext
     {
-        public PaginationContext Pagination { get; set; }
+        public PaginationContext Pagination { get; internal set; }
 
-        public SortingContext Sorting { get; set; }
+        public SortingContext Sorting { get; internal set; }
 
-        public FilteringContext Filtering { get; set; }
+        public FilteringContext Filtering { get; internal set; }
 
-        public IncludingContext Including { get; set; }
+        public IncludingContext Including { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether that query parameters
+        /// will be handled by action itself or Saule should handle them
+        /// </summary>
+        internal bool IsManuallyHandledQuery { get; set; }
 
         public override string ToString()
         {

--- a/Saule/Queries/QueryContext.cs
+++ b/Saule/Queries/QueryContext.cs
@@ -8,14 +8,29 @@ using Saule.Queries.Sorting;
 
 namespace Saule.Queries
 {
+    /// <summary>
+    /// Context with all Json Api operations for current request
+    /// </summary>
     public class QueryContext
     {
+        /// <summary>
+        /// Gets pagination context
+        /// </summary>
         public PaginationContext Pagination { get; internal set; }
 
+        /// <summary>
+        /// Gets sorting context
+        /// </summary>
         public SortingContext Sorting { get; internal set; }
 
+        /// <summary>
+        /// Gets filtering context
+        /// </summary>
         public FilteringContext Filtering { get; internal set; }
 
+        /// <summary>
+        /// Gets including context
+        /// </summary>
         public IncludingContext Including { get; internal set; }
 
         /// <summary>
@@ -24,6 +39,7 @@ namespace Saule.Queries
         /// </summary>
         internal bool IsManuallyHandledQuery { get; set; }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             var result = new List<string>

--- a/Saule/Queries/Sorting/SortContext.cs
+++ b/Saule/Queries/Sorting/SortContext.cs
@@ -6,31 +6,31 @@ namespace Saule.Queries.Sorting
     /// <summary>
     /// Context for sorting operations
     /// </summary>
-    public class SortingContext
+    public class SortContext
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SortingContext"/> class.
+        /// Initializes a new instance of the <see cref="SortContext"/> class.
         /// </summary>
         /// <param name="filters">query string that might contain Sorting keyword</param>
-        public SortingContext(IEnumerable<KeyValuePair<string, string>> filters)
+        public SortContext(IEnumerable<KeyValuePair<string, string>> filters)
         {
             var dict = filters.ToDictionary(kv => kv.Key, kv => kv.Value);
             if (dict.ContainsKey(Constants.QueryNames.Sorting))
             {
                 var props = dict[Constants.QueryNames.Sorting].Split(',').Select(s => s.Trim());
 
-                Properties = props.Select(p => new SortingProperty(p));
+                Properties = props.Select(p => new SortProperty(p));
             }
             else
             {
-                Properties = new SortingProperty[0];
+                Properties = new SortProperty[0];
             }
         }
 
         /// <summary>
         /// Gets sorting properties
         /// </summary>
-        public IEnumerable<SortingProperty> Properties { get; }
+        public IEnumerable<SortProperty> Properties { get; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/Saule/Queries/Sorting/SortDirection.cs
+++ b/Saule/Queries/Sorting/SortDirection.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Direction of sorting
     /// </summary>
-    public enum SortingDirection
+    public enum SortDirection
     {
         /// <summary>
         /// Sort items in ascending order.

--- a/Saule/Queries/Sorting/SortInterpreter.cs
+++ b/Saule/Queries/Sorting/SortInterpreter.cs
@@ -4,12 +4,12 @@ using System.Linq;
 
 namespace Saule.Queries.Sorting
 {
-    internal class SortingInterpreter
+    internal class SortInterpreter
     {
-        private readonly SortingContext _context;
+        private readonly SortContext _context;
         private readonly ApiResource _resource;
 
-        public SortingInterpreter(SortingContext context, ApiResource resource)
+        public SortInterpreter(SortContext context, ApiResource resource)
         {
             _context = context;
             _resource = resource;
@@ -56,21 +56,21 @@ namespace Saule.Queries.Sorting
             return new JsonApiException(ErrorType.Server, $"Attribute '{property.ToDashed()}' not found.", ex);
         }
 
-        private static QueryMethod GetQueryMethod(SortingDirection direction, bool isFirst)
+        private static QueryMethod GetQueryMethod(SortDirection direction, bool isFirst)
         {
             if (isFirst)
             {
-                return direction == SortingDirection.Descending
+                return direction == SortDirection.Descending
                     ? QueryMethod.OrderByDescending
                     : QueryMethod.OrderBy;
             }
 
-            return direction == SortingDirection.Descending
+            return direction == SortDirection.Descending
                 ? QueryMethod.ThenByDescending
                 : QueryMethod.ThenBy;
         }
 
-        private IQueryable ApplyProperty(IQueryable queryable, SortingProperty property, bool isFirst)
+        private IQueryable ApplyProperty(IQueryable queryable, SortProperty property, bool isFirst)
         {
             try
             {
@@ -88,7 +88,7 @@ namespace Saule.Queries.Sorting
             }
         }
 
-        private IEnumerable ApplyProperty(IEnumerable enumerable, SortingProperty property, bool isFirst)
+        private IEnumerable ApplyProperty(IEnumerable enumerable, SortProperty property, bool isFirst)
         {
             try
             {

--- a/Saule/Queries/Sorting/SortProperty.cs
+++ b/Saule/Queries/Sorting/SortProperty.cs
@@ -3,13 +3,13 @@
     /// <summary>
     /// Property for sorting
     /// </summary>
-    public class SortingProperty
+    public class SortProperty
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SortingProperty"/> class.
+        /// Initializes a new instance of the <see cref="SortProperty"/> class.
         /// </summary>
         /// <param name="value">property name and direction</param>
-        public SortingProperty(string value)
+        public SortProperty(string value)
         {
             Direction = FindSortingDirection(value);
             Name = StripSyntax(value).ToPascalCase();
@@ -23,12 +23,12 @@
         /// <summary>
         /// Gets or Sets direction of sorting
         /// </summary>
-        public SortingDirection Direction { get; }
+        public SortDirection Direction { get; }
 
         /// <inheritdoc/>
         public override string ToString()
         {
-            return Direction == SortingDirection.Descending ? "-" + Name : Name;
+            return Direction == SortDirection.Descending ? "-" + Name : Name;
         }
 
         private static string StripSyntax(string value)
@@ -36,11 +36,11 @@
             return value.Trim('+', '-').Trim();
         }
 
-        private static SortingDirection FindSortingDirection(string value)
+        private static SortDirection FindSortingDirection(string value)
         {
             return value.StartsWith("-")
-                ? SortingDirection.Descending
-                : SortingDirection.Ascending;
+                ? SortDirection.Descending
+                : SortDirection.Ascending;
         }
     }
 }

--- a/Saule/Queries/Sorting/SortingContext.cs
+++ b/Saule/Queries/Sorting/SortingContext.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Saule.Queries.Sorting
 {
-    internal class SortingContext
+    public class SortingContext
     {
         public SortingContext(IEnumerable<KeyValuePair<string, string>> filters)
         {

--- a/Saule/Queries/Sorting/SortingContext.cs
+++ b/Saule/Queries/Sorting/SortingContext.cs
@@ -3,8 +3,15 @@ using System.Linq;
 
 namespace Saule.Queries.Sorting
 {
+    /// <summary>
+    /// Context for sorting operations
+    /// </summary>
     public class SortingContext
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SortingContext"/> class.
+        /// </summary>
+        /// <param name="filters">query string that might contain Sorting keyword</param>
         public SortingContext(IEnumerable<KeyValuePair<string, string>> filters)
         {
             var dict = filters.ToDictionary(kv => kv.Key, kv => kv.Value);
@@ -20,8 +27,12 @@ namespace Saule.Queries.Sorting
             }
         }
 
+        /// <summary>
+        /// Gets sorting properties
+        /// </summary>
         public IEnumerable<SortingProperty> Properties { get; }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return $"sort={string.Join(",", Properties)}";

--- a/Saule/Queries/Sorting/SortingDirection.cs
+++ b/Saule/Queries/Sorting/SortingDirection.cs
@@ -1,5 +1,8 @@
 ﻿namespace Saule.Queries.Sorting
 {
+    /// <summary>
+    /// Direction of sorting
+    /// </summary>
     public enum SortingDirection
     {
         /// <summary>

--- a/Saule/Queries/Sorting/SortingDirection.cs
+++ b/Saule/Queries/Sorting/SortingDirection.cs
@@ -1,6 +1,6 @@
 ﻿namespace Saule.Queries.Sorting
 {
-    internal enum SortingDirection
+    public enum SortingDirection
     {
         /// <summary>
         /// Sort items in ascending order.

--- a/Saule/Queries/Sorting/SortingProperty.cs
+++ b/Saule/Queries/Sorting/SortingProperty.cs
@@ -1,17 +1,31 @@
 ﻿namespace Saule.Queries.Sorting
 {
+    /// <summary>
+    /// Property for sorting
+    /// </summary>
     public class SortingProperty
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SortingProperty"/> class.
+        /// </summary>
+        /// <param name="value">property name and direction</param>
         public SortingProperty(string value)
         {
             Direction = FindSortingDirection(value);
             Name = StripSyntax(value).ToPascalCase();
         }
 
+        /// <summary>
+        /// Gets or Sets name of property
+        /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// Gets or Sets direction of sorting
+        /// </summary>
         public SortingDirection Direction { get; }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return Direction == SortingDirection.Descending ? "-" + Name : Name;

--- a/Saule/Queries/Sorting/SortingProperty.cs
+++ b/Saule/Queries/Sorting/SortingProperty.cs
@@ -1,6 +1,6 @@
 ﻿namespace Saule.Queries.Sorting
 {
-    internal class SortingProperty
+    public class SortingProperty
     {
         public SortingProperty(string value)
         {

--- a/Saule/Saule.csproj
+++ b/Saule/Saule.csproj
@@ -64,7 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiResource.cs" />
-    <Compile Include="Http\AllowsManuallyHandledQueryAttribute.cs" />
+    <Compile Include="Http\HandlesQueryAttribute.cs" />
     <Compile Include="Http\JsonApiQueryValueProvider.cs" />
     <Compile Include="Http\JsonApiQueryValueProviderFactory.cs" />
     <Compile Include="JsonApiSerializerOfT.cs" />
@@ -86,20 +86,20 @@
     <Compile Include="NullGuardExtensions.cs" />
     <Compile Include="ObjectExtensions.cs" />
     <Compile Include="PreprocessResult.cs" />
-    <Compile Include="Queries\Filtering\FilteringContext.cs" />
-    <Compile Include="Queries\Filtering\FilteringInterpreter.cs" />
-    <Compile Include="Queries\Filtering\FilteringProperty.cs" />
+    <Compile Include="Queries\Filtering\FilterContext.cs" />
+    <Compile Include="Queries\Filtering\FilterInterpreter.cs" />
+    <Compile Include="Queries\Filtering\FilterProperty.cs" />
     <Compile Include="Http\QueryFilterExpressionCollection.cs" />
     <Compile Include="Queries\Filtering\TypeCorrectingVisitor.cs" />
-    <Compile Include="Queries\Including\IncludingContext.cs" />
-    <Compile Include="Queries\Including\IncludingProperty.cs" />
+    <Compile Include="Queries\Including\IncludeContext.cs" />
+    <Compile Include="Queries\Including\IncludeProperty.cs" />
     <Compile Include="Queries\Lambda.cs" />
     <Compile Include="Queries\Query.cs" />
     <Compile Include="Queries\QueryContext.cs" />
-    <Compile Include="Queries\Sorting\SortingInterpreter.cs" />
-    <Compile Include="Queries\Sorting\SortingContext.cs" />
-    <Compile Include="Queries\Sorting\SortingDirection.cs" />
-    <Compile Include="Queries\Sorting\SortingProperty.cs" />
+    <Compile Include="Queries\Sorting\SortInterpreter.cs" />
+    <Compile Include="Queries\Sorting\SortContext.cs" />
+    <Compile Include="Queries\Sorting\SortDirection.cs" />
+    <Compile Include="Queries\Sorting\SortProperty.cs" />
     <Compile Include="Serialization\ResourceGraphPathSet.cs" />
     <Compile Include="Serialization\ResourceGraphRelationship.cs" />
     <Compile Include="Serialization\ResourceGraph.cs" />

--- a/Saule/Saule.csproj
+++ b/Saule/Saule.csproj
@@ -64,9 +64,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiResource.cs" />
+    <Compile Include="Http\AllowsManuallyHandledQueryAttribute.cs" />
+    <Compile Include="Http\JsonApiQueryValueProvider.cs" />
+    <Compile Include="Http\JsonApiQueryValueProviderFactory.cs" />
     <Compile Include="JsonApiSerializerOfT.cs" />
     <Compile Include="StringDictionaryExtensions.cs" />
-    <Compile Include="FormatterPriority.cs" />    <Compile Include="Http\DisableDefaultIncludedAttribute.cs" />
+    <Compile Include="FormatterPriority.cs" />
+    <Compile Include="Http\DisableDefaultIncludedAttribute.cs" />
     <Compile Include="Http\AllowsQueryAttribute.cs" />
     <Compile Include="Http\HttpConfigExtensions.cs" />
     <Compile Include="Http\JsonApiConfiguration.cs" />

--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -13,7 +13,7 @@ namespace Saule.Serialization
     {
         private readonly Uri _baseUrl;
         private readonly PaginationContext _paginationContext;
-        private readonly IncludingContext _includingContext;
+        private readonly IncludeContext _includeContext;
         private readonly ApiResource _resource;
         private readonly object _value;
         private readonly IUrlPathBuilder _urlBuilder;
@@ -26,15 +26,15 @@ namespace Saule.Serialization
             Uri baseUrl,
             IUrlPathBuilder urlBuilder,
             PaginationContext paginationContext,
-            IncludingContext includingContext)
+            IncludeContext includeContext)
         {
             _urlBuilder = urlBuilder;
             _resource = type;
             _value = value;
             _baseUrl = baseUrl;
             _paginationContext = paginationContext;
-            _includingContext = includingContext;
-            _includedGraphPaths = IncludedGraphPathsFromContext(includingContext);
+            _includeContext = includeContext;
+            _includedGraphPaths = IncludedGraphPathsFromContext(includeContext);
         }
 
         public JObject Serialize()
@@ -103,7 +103,7 @@ namespace Saule.Serialization
             return metaObject == null ? null : JToken.FromObject(metaObject, _serializer);
         }
 
-        private ResourceGraphPathSet IncludedGraphPathsFromContext(IncludingContext context)
+        private ResourceGraphPathSet IncludedGraphPathsFromContext(IncludeContext context)
         {
             if (context == null)
             {
@@ -111,7 +111,7 @@ namespace Saule.Serialization
             }
             else if (context.Includes != null && context.Includes.Any())
             {
-                return new ResourceGraphPathSet(_includingContext.Includes.Select(i => i.Name));
+                return new ResourceGraphPathSet(_includeContext.Includes.Select(i => i.Name));
             }
             else
             {
@@ -202,12 +202,12 @@ namespace Saule.Serialization
             var nodes = graph.IncludedNodes;
 
             // if we have an including context and DisableDefaultIncluded is set
-            if (_includingContext != null && _includingContext.DisableDefaultIncluded)
+            if (_includeContext != null && _includeContext.DisableDefaultIncluded)
             {
                 // if we have specific includes filter nodes otherwise bail with null
-                if (_includingContext.Includes != null)
+                if (_includeContext.Includes != null)
                 {
-                    nodes = nodes.Where(n => _includingContext.Includes.Any(p => p.Name == n.PropertyName));
+                    nodes = nodes.Where(n => _includeContext.Includes.Any(p => p.Name == n.PropertyName));
                 }
                 else
                 {

--- a/Tests/Controllers/BrokenController.cs
+++ b/Tests/Controllers/BrokenController.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Web.Http;
 using Saule.Http;
+using Saule.Queries;
 using Tests.Helpers;
 using Tests.Models;
 
@@ -65,5 +66,24 @@ namespace Tests.Controllers
         {
             throw new InvalidOperationException("Test exception");
         }
+
+        [HttpGet]
+        [HandlesQuery]
+        [DisableDefaultIncluded]
+        [Route("api/broken/manual/disabledefault")]
+        public IQueryable<Person> ManualQueryAndDisableDefault(QueryContext context)
+        {
+            return Get.People(1).AsQueryable();
+        }
+
+        [HttpGet]
+        [HandlesQuery]
+        [AllowsQuery]
+        [Route("api/broken/manual/allowsquery")]
+        public IQueryable<Person> ManualQueryAndAllowsQuery(QueryContext context)
+        {
+            return Get.People(1).AsQueryable();
+        }
+
     }
 }

--- a/Tests/Controllers/PeopleController.cs
+++ b/Tests/Controllers/PeopleController.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Web.Http;
 using Saule.Http;
+using Saule.Queries;
 using Tests.Helpers;
 using Tests.Models;
 
@@ -44,6 +45,77 @@ namespace Tests.Controllers
             return GetPeopleNotRandom();
         }
 
+        [HttpGet]
+        [AllowsManuallyHandledQuery]
+        [Paginated]
+        [DisableDefaultIncluded]
+        [Route("query/manual/paginate/people")]
+        public IEnumerable<Person> ManualQueryAndPaginatePeople(QueryContext context)
+        {
+            IEnumerable<Person> data = GetPeopleNotRandom(10).ToList();
+            
+            bool? hideLastName;
+            // if we want to include car or job, then we return response as is as it already has them
+            // otherwise we clear it
+            bool includeCar = context.Including.Includes.Any(p => p.Name == nameof(Person.Car));
+            bool includeJob = context.Including.Includes.Any(p => p.Name == nameof(Person.Job));
+
+            context.Filtering.TryGetValue("HideLastName", out hideLastName);
+
+            if (hideLastName.GetValueOrDefault() || !includeCar)
+            {
+                foreach (var person in data)
+                {
+                    if (hideLastName.GetValueOrDefault())
+                    {
+                        person.LastName = null;
+                    }
+
+                    if (!includeCar)
+                        person.Car = null;
+
+                    if (!includeJob)
+                        person.Job = null;
+                }
+            }
+
+            int? minAge;
+            if (context.Filtering.TryGetValue("MinAge", out minAge) && minAge.HasValue)
+            {
+                data = data.Where(person => person.Age >= minAge);
+            }
+
+            if (context.Pagination.PerPage.HasValue)
+            {
+                data = data.Take(context.Pagination.PerPage.Value);
+            }
+
+            return data;
+        }
+
+        [HttpGet]
+        [AllowsManuallyHandledQuery]
+        [Route("query/manual-typed/people")]
+        public IEnumerable<Person> ManualTypedQueryAndPaginatePeople([FromUri] PersonFilter filter)
+        {
+            IEnumerable<Person> data = GetPeopleNotRandom(10).ToList();
+            if (filter?.HideLastName == true)
+            {
+                foreach (var person in data)
+                {
+                    person.LastName = null;
+                }
+            }
+
+            if (filter?.MinAge != null)
+            {
+                data = data.Where(person => person.Age >= filter.MinAge);
+            }
+
+            return data;
+        }
+
+
         [HttpPost]
         [Route("people/{id}")]
         public Person PostPerson(string id, Person person)
@@ -59,9 +131,9 @@ namespace Tests.Controllers
             return Get.People(100);
         }
 
-        private static IEnumerable<Person> GetPeopleNotRandom()
+        private static IEnumerable<Person> GetPeopleNotRandom(int count = 100)
         {
-            for (var i = 0; i < 100; i++)
+            for (var i = 0; i < count; i++)
             {
                 var person = Get.Person(i.ToString());
                 person.Age = i + 2;

--- a/Tests/Controllers/PeopleController.cs
+++ b/Tests/Controllers/PeopleController.cs
@@ -46,9 +46,8 @@ namespace Tests.Controllers
         }
 
         [HttpGet]
-        [AllowsManuallyHandledQuery]
+        [HandlesQuery]
         [Paginated]
-        [DisableDefaultIncluded]
         [Route("query/manual/paginate/people")]
         public IEnumerable<Person> ManualQueryAndPaginatePeople(QueryContext context)
         {
@@ -57,10 +56,10 @@ namespace Tests.Controllers
             bool? hideLastName;
             // if we want to include car or job, then we return response as is as it already has them
             // otherwise we clear it
-            bool includeCar = context.Including.Includes.Any(p => p.Name == nameof(Person.Car));
-            bool includeJob = context.Including.Includes.Any(p => p.Name == nameof(Person.Job));
+            bool includeCar = context.Include.Includes.Any(p => p.Name == nameof(Person.Car));
+            bool includeJob = context.Include.Includes.Any(p => p.Name == nameof(Person.Job));
 
-            context.Filtering.TryGetValue("HideLastName", out hideLastName);
+            context.Filter.TryGetValue("HideLastName", out hideLastName);
 
             if (hideLastName.GetValueOrDefault() || !includeCar)
             {
@@ -80,7 +79,7 @@ namespace Tests.Controllers
             }
 
             int? minAge;
-            if (context.Filtering.TryGetValue("MinAge", out minAge) && minAge.HasValue)
+            if (context.Filter.TryGetValue("MinAge", out minAge) && minAge.HasValue)
             {
                 data = data.Where(person => person.Age >= minAge);
             }
@@ -94,7 +93,7 @@ namespace Tests.Controllers
         }
 
         [HttpGet]
-        [AllowsManuallyHandledQuery]
+        [HandlesQuery]
         [Route("query/manual-typed/people")]
         public IEnumerable<Person> ManualTypedQueryAndPaginatePeople([FromUri] PersonFilter filter)
         {

--- a/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
+++ b/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
@@ -537,6 +537,27 @@ namespace Tests.Integration
         }
 
 
+        [Theory(DisplayName = "Denies other attributes when HandlesQueryAttribute is specified")]
+        [InlineData("api/broken/manual/disabledefault", "DisableDefaultIncludedAttribute shouldn't be used with HandlesQueryAttribute.")]
+        [InlineData("api/broken/manual/allowsquery", "AllowsQueryAttribute shouldn't be used with HandlesQueryAttribute.")]
+        public async Task DenyOtherAttributesForHandlesQuery(string query, string expectedTitle)
+        {
+            using (var server = new NewSetupJsonApiServer(new JsonApiConfiguration()))
+            {
+                var client = server.GetClient();
+
+                var response = await client.GetFullJsonResponseAsync(query);
+                var error = response.Content["errors"][0];
+
+                Assert.Equal("Saule.JsonApiException", error["code"].Value<string>());
+
+                Assert.Equal(expectedTitle, error["title"].Value<string>());
+
+                Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            }
+        }
+
+
         [Fact(DisplayName = "Applies filtering when appropriate")]
         public async Task AppliesFiltering()
         {

--- a/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
+++ b/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Converters;
@@ -449,6 +450,92 @@ namespace Tests.Integration
                 Assert.Equal(sorted, ages);
             }
         }
+
+
+        [Theory(DisplayName = "Applies manual filtering when appropriate")]
+        [InlineData("api/query/manual-typed/people", 10, null, 2)]
+        [InlineData("api/query/manual-typed/people", 10, true, 2)]
+        [InlineData("api/query/manual-typed/people", 10, false, 2)]
+        [InlineData("api/query/manual-typed/people", 2, null, 10)]
+        [InlineData("api/query/manual-typed/people", null, null, 10)]
+        [InlineData("api/query/manual/paginate/people", 10, null, 2)]
+        [InlineData("api/query/manual/paginate/people", 2, null, 10)]
+        [InlineData("api/query/manual/paginate/people", null, null, 10)]
+        [InlineData("api/query/manual/paginate/people", null, true, 10)]
+        [InlineData("api/query/manual/paginate/people", null, false, 10)]
+        [InlineData("api/query/manual/paginate/people?page[size]=4", null, true, 4)]
+        [InlineData("api/query/manual/paginate/people?page[size]=4", null, null, 4)]
+        // it should have 2 items and with page.size == 1 it should return just one of them
+        [InlineData("api/query/manual/paginate/people?page[size]=1", 10, null, 1)]
+        [InlineData("api/query/manual/paginate/people?page[size]=1", null, null, 1)]
+        // we return only 10 persons in controller
+        [InlineData("api/query/manual/paginate/people?page[size]=100", null, null, 10)] 
+        public async Task AppliesManualFiltering(string query, int? minAge, bool? hideLastName, int expectedSize)
+        {
+            using (var server = new NewSetupJsonApiServer(new JsonApiConfiguration()))
+            {
+                var client = server.GetClient();
+                if (minAge.HasValue)
+                {
+                    query += $"{(query.Contains("?") ? "&" : "?")}filter[min-age]={minAge}";
+                }
+
+                if (hideLastName.HasValue)
+                {
+                    query += $"{(query.Contains("?") ? "&" : "?")}filter[hide-last-name]={hideLastName.Value}";
+                }
+
+                var result = await client.GetJsonResponseAsync(query);
+                var data = (JArray) result["data"];
+
+                var allLastNamesMissing = data.All(
+                    p => string.IsNullOrWhiteSpace(p["attributes"]["last-name"].Value<string>()));
+
+                // calculate count of returned records that satisfy condition
+                var validCount = data.Count(p =>
+                    !minAge.HasValue ||
+                    p["attributes"]["age"].Value<int>() >= minAge.Value);
+
+                var totalCount = ((JArray)result["data"]).Count;
+
+                Assert.Equal(expectedSize, validCount);
+                Assert.Equal(totalCount, validCount);
+
+                if (hideLastName.HasValue)
+                {
+                    Assert.Equal(hideLastName.Value, allLastNamesMissing);
+                }
+            }
+        }
+
+        [Theory(DisplayName = "Applies manual filtering when appropriate")]
+        [InlineData("api/query/manual/paginate/people", new string[0])]
+        [InlineData("api/query/manual/paginate/people?include=car,job", new[] { "car", "corporation" })]
+        [InlineData("api/query/manual/paginate/people?include=car", new[] { "car"})]
+        [InlineData("api/query/manual/paginate/people?include=job", new[] { "corporation" })]
+        public async Task AppliesManualIncluding(string query, string[] expectedIncludes)
+        {
+            using (var server = new NewSetupJsonApiServer(new JsonApiConfiguration()))
+            {
+                var client = server.GetClient();
+
+                var result = await client.GetJsonResponseAsync(query);
+
+                // get all types that were included
+                var includedTypes = ((JArray) result["included"])
+                                    ?.Select(p => p["type"].Value<string>())
+                                    .Distinct()
+                                    .ToList() ?? new List<string>();
+
+                Assert.Equal(includedTypes.Count, expectedIncludes.Length);
+
+                foreach (var expectedInclude in expectedIncludes)
+                {
+                    Assert.Contains(expectedInclude, includedTypes);
+                }
+            }
+        }
+
 
         [Fact(DisplayName = "Applies filtering when appropriate")]
         public async Task AppliesFiltering()

--- a/Tests/Models/PersonFilter.cs
+++ b/Tests/Models/PersonFilter.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests.Models
+{
+    public class PersonFilter
+    {
+        public bool HideLastName { get; set; }
+        public int? MinAge { get; set; }
+    }
+}

--- a/Tests/Queries/FilterInterpreterTests.cs
+++ b/Tests/Queries/FilterInterpreterTests.cs
@@ -11,9 +11,9 @@ using Xunit;
 
 namespace Tests.Queries
 {
-    public class FilteringInterpreterTests
+    public class FilterInterpreterTests
     {
-        private static FilteringContext DefaultContext => new FilteringContext(GetQuery(
+        private static FilterContext DefaultContext => new FilterContext(GetQuery(
             new[] { "id" },
             new[] { "5" }));
 
@@ -29,7 +29,7 @@ namespace Tests.Queries
         [Fact(DisplayName = "Doesn't do anything on empty queryable/enumerable")]
         public void EmptyIsNoop()
         {
-            var target = new FilteringInterpreter(DefaultContext, new PersonResource());
+            var target = new FilterInterpreter(DefaultContext, new PersonResource());
             var enumerableResult = target.Apply(Enumerable.Empty<Person>()) as IEnumerable<Person>;
             var queryableResult = target.Apply(Enumerable.Empty<Person>().AsQueryable()) as IQueryable<Person>;
 
@@ -44,7 +44,7 @@ namespace Tests.Queries
         [InlineData(new[] { "last-name", "first-name" }, new[] { "Smith", "John" }, new[] { "LastName", "FirstName" })]
         internal void ParsesCorrectly(string[] names, string[] values, string[] properties)
         {
-            var context = new FilteringContext(GetQuery(names, values));
+            var context = new FilterContext(GetQuery(names, values));
             var expected = properties.Zip(values, (n, v) => new
             {
                 Name = n,
@@ -62,11 +62,11 @@ namespace Tests.Queries
         [Fact(DisplayName = "Parses empty query string correctly")]
         public void ParsesEmpty()
         {
-            var context = new FilteringContext(Enumerable.Empty<KeyValuePair<string, string>>());
+            var context = new FilterContext(Enumerable.Empty<KeyValuePair<string, string>>());
 
             var actual = context.Properties;
 
-            Assert.Equal(Enumerable.Empty<FilteringProperty>(), actual);
+            Assert.Equal(Enumerable.Empty<FilterProperty>(), actual);
         }
 
         [Fact(DisplayName = "Applies filtering on enums (int)")]
@@ -77,7 +77,7 @@ namespace Tests.Queries
 
             var query = GetQuery(new[] { "Location" }, new[] { "1" });
 
-            var result = Query.ApplyFiltering(companies, new FilteringContext(query), new CompanyResource())
+            var result = Query.ApplyFiltering(companies, new FilterContext(query), new CompanyResource())
                 as IQueryable<Company>;
 
             Assert.Equal(expected, result);
@@ -91,7 +91,7 @@ namespace Tests.Queries
 
             var query = GetQuery(new[] { "Age" }, new[] { "20" });
 
-            var result = Query.ApplyFiltering(people, new FilteringContext(query), new PersonResource())
+            var result = Query.ApplyFiltering(people, new FilterContext(query), new PersonResource())
                 as IQueryable<Person>;
 
             Assert.Equal(expected, result);
@@ -105,7 +105,7 @@ namespace Tests.Queries
 
             var query = GetQuery(new[] { "Location" }, new[] { "national" });
 
-            var result = Query.ApplyFiltering(companies, new FilteringContext(query), new CompanyResource())
+            var result = Query.ApplyFiltering(companies, new FilterContext(query), new CompanyResource())
                 as IQueryable<Company>;
 
             Assert.Equal(expected, result);
@@ -119,7 +119,7 @@ namespace Tests.Queries
 
             var query = GetQuery(new[] { "LastName" }, new[] { "Russel" });
 
-            var result = Query.ApplyFiltering(people, new FilteringContext(query), new PersonResource())
+            var result = Query.ApplyFiltering(people, new FilterContext(query), new PersonResource())
                 as IQueryable<Person>;
 
             Assert.Equal(expected, result);
@@ -133,7 +133,7 @@ namespace Tests.Queries
 
             var query = GetQuery(new[] { "LastName" }, new[] { "Russel" });
 
-            var result = Query.ApplyFiltering(people, new FilteringContext(query), new PersonResource())
+            var result = Query.ApplyFiltering(people, new FilterContext(query), new PersonResource())
                 as IEnumerable<Person>;
 
             Assert.Equal(expected, result);
@@ -148,9 +148,9 @@ namespace Tests.Queries
             var query = GetQuery(new[] { "Fake" }, new[] { "no" });
 
             Assert.Throws<JsonApiException>(() =>
-                Query.ApplyFiltering(enumerable, new FilteringContext(query), new PersonResource()));
+                Query.ApplyFiltering(enumerable, new FilterContext(query), new PersonResource()));
             Assert.Throws<JsonApiException>(() =>
-                Query.ApplyFiltering(queryable, new FilteringContext(query), new PersonResource()));
+                Query.ApplyFiltering(queryable, new FilterContext(query), new PersonResource()));
         }
 
         private static IEnumerable<KeyValuePair<string, string>> GetQuery(IEnumerable<string> properties, IEnumerable<string> values)

--- a/Tests/Queries/SortInterpreterTests.cs
+++ b/Tests/Queries/SortInterpreterTests.cs
@@ -9,9 +9,9 @@ using Xunit;
 
 namespace Tests.Queries
 {
-    public class SortingInterpreterTests
+    public class SortInterpreterTests
     {
-        private static SortingContext DefaultContext => new SortingContext(GetQuery("id"));
+        private static SortContext DefaultContext => new SortContext(GetQuery("id"));
 
         [Fact(DisplayName = "Does not do anything to non-enumerables/queryables")]
         public void IgnoresNonEnumerables()
@@ -25,7 +25,7 @@ namespace Tests.Queries
         [Fact(DisplayName = "Doesn't do anything on empty queryable/enumerable")]
         public void EmptyIsNoop()
         {
-            var target = new SortingInterpreter(DefaultContext, new PersonResource());
+            var target = new SortInterpreter(DefaultContext, new PersonResource());
             var enumerableResult = target.Apply(Enumerable.Empty<Person>()) as IEnumerable<Person>;
             var queryableResult = target.Apply(Enumerable.Empty<Person>().AsQueryable()) as IQueryable<Person>;
 
@@ -34,15 +34,15 @@ namespace Tests.Queries
         }
 
         [Theory(DisplayName = "Parses sorting string value correctly")]
-        [InlineData("+id", new[] { "Id" }, new[] { SortingDirection.Ascending })]
-        [InlineData("-id", new[] { "Id" }, new[] { SortingDirection.Descending })]
-        [InlineData("id", new[] { "Id" }, new[] { SortingDirection.Ascending })]
-        [InlineData("id,-age", new[] { "Id", "Age" }, new[] { SortingDirection.Ascending, SortingDirection.Descending })]
-        [InlineData("+id,age", new[] { "Id", "Age" }, new[] { SortingDirection.Ascending, SortingDirection.Ascending })]
-        [InlineData("+id,-id", new[] { "Id", "Id" }, new[] { SortingDirection.Ascending, SortingDirection.Descending })]
-        internal void ParsesCorrectly(string query, string[] properties, SortingDirection[] directions)
+        [InlineData("+id", new[] { "Id" }, new[] { SortDirection.Ascending })]
+        [InlineData("-id", new[] { "Id" }, new[] { SortDirection.Descending })]
+        [InlineData("id", new[] { "Id" }, new[] { SortDirection.Ascending })]
+        [InlineData("id,-age", new[] { "Id", "Age" }, new[] { SortDirection.Ascending, SortDirection.Descending })]
+        [InlineData("+id,age", new[] { "Id", "Age" }, new[] { SortDirection.Ascending, SortDirection.Ascending })]
+        [InlineData("+id,-id", new[] { "Id", "Id" }, new[] { SortDirection.Ascending, SortDirection.Descending })]
+        internal void ParsesCorrectly(string query, string[] properties, SortDirection[] directions)
         {
-            var context = new SortingContext(GetQuery(query));
+            var context = new SortContext(GetQuery(query));
             var expected = properties.Zip(directions, (s, d) => new
             {
                 Name = s,
@@ -60,11 +60,11 @@ namespace Tests.Queries
         [Fact(DisplayName = "Parses empty query string correctly")]
         public void ParsesEmpty()
         {
-            var context = new SortingContext(Enumerable.Empty<KeyValuePair<string, string>>());
+            var context = new SortContext(Enumerable.Empty<KeyValuePair<string, string>>());
 
             var actual = context.Properties;
 
-            Assert.Equal(Enumerable.Empty<SortingProperty>(), actual);
+            Assert.Equal(Enumerable.Empty<SortProperty>(), actual);
         }
 
         [Fact(DisplayName = "Applies sorting order (asc,desc)")]
@@ -73,7 +73,7 @@ namespace Tests.Queries
             var people = Get.People(100).ToList().AsQueryable();
             var expected = people.OrderBy(p => p.Age).ThenByDescending(p => p.Identifier);
 
-            var result = Query.ApplySorting(people, new SortingContext(GetQuery("age,-id")), new PersonResource())
+            var result = Query.ApplySorting(people, new SortContext(GetQuery("age,-id")), new PersonResource())
                 as IQueryable<Person>;
 
             Assert.Equal(expected, result);
@@ -85,7 +85,7 @@ namespace Tests.Queries
             var people = Get.People(100).ToList().AsQueryable();
             var expected = people.OrderBy(p => p.Age).ThenBy(p => p.Identifier);
 
-            var result = Query.ApplySorting(people, new SortingContext(GetQuery("age,id")), new PersonResource())
+            var result = Query.ApplySorting(people, new SortContext(GetQuery("age,id")), new PersonResource())
                 as IQueryable<Person>;
 
             Assert.Equal(expected, result);
@@ -97,7 +97,7 @@ namespace Tests.Queries
             var people = Get.People(100).ToList();
             var expected = people.OrderBy(p => p.Age).ThenBy(p => p.Identifier);
 
-            var result = Query.ApplySorting(people, new SortingContext(GetQuery("age,id")), new PersonResource())
+            var result = Query.ApplySorting(people, new SortContext(GetQuery("age,id")), new PersonResource())
                 as IEnumerable<Person>;
 
             Assert.Equal(expected, result);
@@ -109,7 +109,7 @@ namespace Tests.Queries
             var people = Get.People(100).ToList();
             var expected = people.OrderBy(p => p.Age).ThenByDescending(p => p.Identifier);
 
-            var result = Query.ApplySorting(people, new SortingContext(GetQuery("age,-id")), new PersonResource())
+            var result = Query.ApplySorting(people, new SortContext(GetQuery("age,-id")), new PersonResource())
                 as IEnumerable<Person>;
 
             Assert.Equal(expected, result);

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -264,7 +264,7 @@ namespace Tests.Serialization
         [Fact(DisplayName = "Do not serialize relationship data into 'included' key when includedDefault set to false")]
         public void NoIncludedRelationshipData()
         {
-            var includes = new IncludingContext();
+            var includes = new IncludeContext();
             includes.DisableDefaultIncluded = true;
             var target = new ResourceSerializer(DefaultObject, DefaultResource,
                 GetUri(id: "123"), DefaultPathBuilder, null, includes);
@@ -280,7 +280,7 @@ namespace Tests.Serialization
         [Fact(DisplayName = "Serialize only included relationship data into 'included' key when includedDefault set to false")]
         public void OnlyIncludedRelationshipData()
         {
-            var includes = new IncludingContext();
+            var includes = new IncludeContext();
             includes.DisableDefaultIncluded = true;
             var includeParam = new KeyValuePair<string, string>("include", "job");
             includes.SetIncludes(new List<KeyValuePair<string, string>>() { includeParam });
@@ -298,7 +298,7 @@ namespace Tests.Serialization
         [Fact(DisplayName = "Serialize relationship identifier objects into 'data' key when includedDefault set to true")]
         public void IncludedRelationshipIdentifierObjects()
         {
-            var includes = new IncludingContext();
+            var includes = new IncludeContext();
             includes.DisableDefaultIncluded = true;
             var target = new ResourceSerializer(DefaultObject, DefaultResource,
                 GetUri(id: "123"), DefaultPathBuilder, null, includes);
@@ -315,7 +315,7 @@ namespace Tests.Serialization
         [Fact(DisplayName = "Omit data for relationship objects not existing as property in the original model")]
         public void OmitRelationshipIdentifierObjectsWithoutProperty()
         {
-            var includes = new IncludingContext();
+            var includes = new IncludeContext();
             includes.DisableDefaultIncluded = true;
             var target = new ResourceSerializer(DefaultObject, DefaultResource,
                 GetUri(id: "123"), DefaultPathBuilder, null, includes);
@@ -364,7 +364,7 @@ namespace Tests.Serialization
                 }
             };
 
-            var include = new IncludingContext(GetQuery("include", "friends.job"));
+            var include = new IncludeContext(GetQuery("include", "friends.job"));
             var target = new ResourceSerializer(person, DefaultResource,
                 GetUri(id: "123"), DefaultPathBuilder, null, include);
             var result = target.Serialize();
@@ -380,7 +380,7 @@ namespace Tests.Serialization
         {
             var person = new Person(id: "45");
             var target = new ResourceSerializer(person, DefaultResource,
-                GetUri(id: "45"), DefaultPathBuilder, null, new IncludingContext { DisableDefaultIncluded = true });
+                GetUri(id: "45"), DefaultPathBuilder, null, new IncludeContext { DisableDefaultIncluded = true });
 
             var result = target.Serialize();
             _output.WriteLine(result.ToString());

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Helpers\ObsoleteSetupJsonApiServer.cs" />
     <Compile Include="Helpers\Paths.cs" />
     <Compile Include="Models\LazyPerson.cs" />
+    <Compile Include="Models\PersonFilter.cs" />
     <Compile Include="Models\PersonJobOnlyRelatedLinksResource.cs" />
     <Compile Include="Models\PersonJobOnlySelfLinksResource.cs" />
     <Compile Include="Models\PersonNoJobLinksResource.cs" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -161,8 +161,8 @@
     </Compile>
     <Compile Include="Helpers\NotOrderedQueryable.cs" />
     <Compile Include="Queries\PaginationInterpreterTests.cs" />
-    <Compile Include="Queries\FilteringInterpreterTests.cs" />
-    <Compile Include="Queries\SortingInterpreterTests.cs" />
+    <Compile Include="Queries\FilterInterpreterTests.cs" />
+    <Compile Include="Queries\SortInterpreterTests.cs" />
     <Compile Include="Queries\PaginationQueryTests.cs" />
     <Compile Include="Serialization\CanonicalUrlPathBuilderTests.cs" />
     <Compile Include="Serialization\DefaultUrlPathBuilderTests.cs" />


### PR DESCRIPTION
Hi Jouke,

Here is pull request for issue https://github.com/joukevandermaas/saule/issues/120 . In our case we don't use EntityFramework, but we want to consume already parsed parameters (include\filters\page\sort), so then we can handle them manually in our WebApi controllers\actions. Current issue is that if i specify `AllowsQueryAttribute`, then Saule will parse request and will try to apply it automatically that isn't what we need. I tried to follow your comments in that ticket by making `QueryContext` as publicly accessible, but with internal setters, so for external callers it will be immutable

This pull request tries to handle such use cases:
1. Provide immutable `QueryContext` to WebApi action, so action can handle it manually. There is a code in `AllowsManuallyHandledQueryAttribute` that passes current `QueryContext` to action if action has it as parameter. For example in case of Include, we can check what properties were specified in `QueryContext` and only then we would load them from our persistent storage. Otherwise we won't load them. Currently Saule does't allow to us to do it and we need to load the whole entity with `DisableDefaultIncluded` attribute, and then Saule will include specified properties. But not all consumer needs all properties.
2. Disable internal Saule handling for sort\page\filter
3. Allow user to use fields in filter that aren't present in actual model. For example we have entity and it can have different IsDeleted state, and we want to specify it like `&filter[include-ancient-records]=true` and right now Saule will fail here as it requires that `IncludeAncientRecords` should be present in entity itself
4. Allow automatic WebApi binding for filters. As filter properties can be specified in kebab case - WebApi won't map them, so i added `JsonApiQueryValueProvider` that gets parameters from query, and then converts them to PascalCase, so WebApi can bind them. Use case here is that we can have own `PersonFilter` like in added tests, where i can specify custom properties. I'm a bit afraid that it will affect something else, but it should be used after default `QueryStringValueProvider` so it will have lower priority in model binding


I added 19 unit tests that should validate these cases. And also i verified that existing unit tests are still valid and passes.
I also have some doubts about naming and not sure that `ManuallyHandledQuery` is good description for that, so i'm totally open for any other suggestions. 

I haven't updated any docs, as i'm sure you will have some comments about code and it might need more changes. but if you want, i can add some documenation to docs/content folder about this feature

Thanks!