### PR TITLE
Fix regression with omitted data

### DIFF
--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -323,7 +323,7 @@ namespace Saule.Serialization
                     item["links"] = links;
                 }
 
-                if (data != null && kv.Value != null && kv.Value.SourceObject != null)
+                if (data != null && kv.Value != null)
                 {
                     item["data"] = data;
                 }

--- a/Tests/JsonApiSerializerTests.cs
+++ b/Tests/JsonApiSerializerTests.cs
@@ -68,21 +68,6 @@ namespace Tests
 
         }
 
-        [Fact(DisplayName = "Does not include relationship data when the relationship is null")]
-        public void DoesNotIncludeNullData()
-        {
-            var target = new JsonApiSerializer<PersonResource>();
-            var model = new Person()
-            {
-                Identifier = "Id",
-                Job = null
-            };
-
-            var result = target.Serialize(model, DefaultUrl);
-
-             Assert.Null(result["data"]["relationships"]["job"]["data"]);
-        }
-
         [Fact(DisplayName = "Does not allow null Uri")]
         public void HasAContract()
         {

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -411,8 +411,8 @@ namespace Tests.Serialization
             Assert.NotNull(attributes["last-name"]);
             Assert.NotNull(attributes["age"]);
 
-            Assert.Equal(0, relationships["job"]["data"].Count());
-            Assert.Equal(0, relationships["friends"]["data"].Count());
+            Assert.Equal(JTokenType.Null, relationships["job"]["data"].Type);
+            Assert.Equal(JTokenType.Null, relationships["friends"]["data"].Type);
         }
 
         [Fact(DisplayName = "Serializes enumerables properly")]

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -412,7 +412,7 @@ namespace Tests.Serialization
             Assert.NotNull(attributes["age"]);
 
             Assert.Equal(JTokenType.Null, relationships["job"]["data"].Type);
-            Assert.Equal(JTokenType.Null, relationships["friends"]["data"].Type);
+            Assert.Empty(relationships["friends"]["data"]);
         }
 
         [Fact(DisplayName = "Serializes enumerables properly")]

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -226,7 +226,7 @@ namespace Tests.Serialization
             });
         }
 
-        [Fact(DisplayName = "Serializes relationship data only if it exists")]
+        [Fact(DisplayName = "Serializes relationship data only if it exists as model property")]
         public void SerializesRelationshipData()
         {
             var person = new PersonWithNoJob();
@@ -240,6 +240,25 @@ namespace Tests.Serialization
             var friends = relationships["friends"];
 
             Assert.Null(job["data"]);
+
+            Assert.NotNull(friends);
+        }
+
+        [Fact(DisplayName = "Serializes relationship data as null if empty one to one")]
+        public void SerializesRelationshipDataAsNull()
+        {
+            var person = Get.Person(id: "123");
+            person.Job = null;
+            var target = new ResourceSerializer(person, DefaultResource,
+                GetUri(id: "123"), DefaultPathBuilder, null, null);
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            var relationships = result["data"]["relationships"];
+            var job = relationships["job"];
+            var friends = relationships["friends"];
+
+            Assert.Equal(JTokenType.Null, job["data"].Type);
 
             Assert.NotNull(friends);
         }
@@ -392,8 +411,8 @@ namespace Tests.Serialization
             Assert.NotNull(attributes["last-name"]);
             Assert.NotNull(attributes["age"]);
 
-            Assert.Null(relationships["job"]["data"]);
-            Assert.Null(relationships["friends"]["data"]);
+            Assert.Equal(0, relationships["job"]["data"].Count());
+            Assert.Equal(0, relationships["friends"]["data"].Count());
         }
 
         [Fact(DisplayName = "Serializes enumerables properly")]


### PR DESCRIPTION
Regression was caused by https://github.com/joukevandermaas/saule/pull/180. When a one-to-one relationship is empty data would be omitted and that is invalid for a relationship object without links - and it would be unfortunate to be forced to include links for nullable one-to-one relationships.