### PR TITLE
opt into JsonApi per webapi endpoint

### DIFF
--- a/Saule/Http/JsonApiAttribute.cs
+++ b/Saule/Http/JsonApiAttribute.cs
@@ -31,7 +31,7 @@ namespace Saule.Http
             var formatter = new JsonApiMediaTypeFormatter(new JsonApiConfiguration()).GetPerRequestFormatterInstance(
                 typeof(string),
                 actionExecutedContext.Request,
-                new MediaTypeHeaderValue("application/vnd.api+json"));
+                new MediaTypeHeaderValue(Constants.MediaType));
 
             actionExecutedContext.Response.Content = new ObjectContent(content.ObjectType, content.Value, formatter);
         }

--- a/Saule/Http/JsonApiAttribute.cs
+++ b/Saule/Http/JsonApiAttribute.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Web.Http.Filters;
+
+namespace Saule.Http
+{
+    /// <summary>
+    /// An optional attribute that can be used to opt an api into returning a JsonApi response.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public sealed class JsonApiAttribute : ActionFilterAttribute
+    {
+        /// <summary>
+        /// See base class documentation.
+        /// </summary>
+        /// <param name="actionExecutedContext">The action context.</param>
+        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+        {
+            if (actionExecutedContext.Exception != null)
+            {
+                return;
+            }
+
+            var content = actionExecutedContext.Response.Content as ObjectContent;
+            if (content == null)
+            {
+                return;
+            }
+
+            var formatter = new JsonApiMediaTypeFormatter(new JsonApiConfiguration()).GetPerRequestFormatterInstance(
+                typeof(string),
+                actionExecutedContext.Request,
+                new MediaTypeHeaderValue("application/vnd.api+json"));
+
+            actionExecutedContext.Response.Content = new ObjectContent(content.ObjectType, content.Value, formatter);
+        }
+    }
+}

--- a/Saule/Http/JsonApiAttribute.cs
+++ b/Saule/Http/JsonApiAttribute.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Web.Http.Filters;
 
 namespace Saule.Http
@@ -9,31 +7,15 @@ namespace Saule.Http
     /// An optional attribute that can be used to opt an api into returning a JsonApi response.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
-    public sealed class JsonApiAttribute : ActionFilterAttribute
+    public class JsonApiAttribute : ActionFilterAttribute
     {
         /// <summary>
         /// See base class documentation.
         /// </summary>
-        /// <param name="actionExecutedContext">The action context.</param>
-        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+        /// <param name="context">The action context.</param>
+        public override void OnActionExecuted(HttpActionExecutedContext context)
         {
-            if (actionExecutedContext.Exception != null)
-            {
-                return;
-            }
-
-            var content = actionExecutedContext.Response.Content as ObjectContent;
-            if (content == null)
-            {
-                return;
-            }
-
-            var formatter = new JsonApiMediaTypeFormatter(new JsonApiConfiguration()).GetPerRequestFormatterInstance(
-                typeof(string),
-                actionExecutedContext.Request,
-                new MediaTypeHeaderValue(Constants.MediaType));
-
-            actionExecutedContext.Response.Content = new ObjectContent(content.ObjectType, content.Value, formatter);
+            JsonApiProcessor.ProcessRequest(context);
         }
     }
 }

--- a/Saule/Http/JsonApiProcessor.cs
+++ b/Saule/Http/JsonApiProcessor.cs
@@ -50,7 +50,7 @@ namespace Saule.Http
                 return;
             }
 
-            var formatter = new JsonApiMediaTypeFormatter(new JsonApiConfiguration()).GetPerRequestFormatterInstance(
+            var formatter = new JsonApiMediaTypeFormatter(config).GetPerRequestFormatterInstance(
                 typeof(string),
                 context.Request,
                 new MediaTypeHeaderValue(Constants.MediaType));

--- a/Saule/Http/JsonApiProcessor.cs
+++ b/Saule/Http/JsonApiProcessor.cs
@@ -1,0 +1,61 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Web.Http.Filters;
+using Saule.Serialization;
+
+namespace Saule.Http
+{
+    /// <summary>
+    /// Processes JSON API responses
+    /// </summary>
+    public class JsonApiProcessor
+    {
+        /// <summary>
+        /// process request as JSON API response
+        /// </summary>
+        /// <param name="context">context</param>
+        public static void ProcessRequest(HttpActionExecutedContext context)
+        {
+            var statusCode = (int)context.Response.StatusCode;
+            if (statusCode >= 400 && statusCode < 500)
+            {
+                // probably malformed request or not found
+                return;
+            }
+
+            var value = context.Response.Content as ObjectContent;
+
+            var config = new JsonApiConfiguration();
+
+            var content = PreprocessingDelegatingHandler.PreprocessRequest(value?.Value, context.Request, config);
+
+            if (content.ErrorContent != null)
+            {
+                context.Response.StatusCode = ApiError.IsClientError(content.ErrorContent)
+                    ? HttpStatusCode.BadRequest
+                    : HttpStatusCode.InternalServerError;
+            }
+
+            context.Request.Properties.Add(Constants.PropertyNames.PreprocessResult, content);
+
+            if (context.Exception != null)
+            {
+                return;
+            }
+
+            var responseContent = context.Response.Content as ObjectContent;
+            if (responseContent == null)
+            {
+                return;
+            }
+
+            var formatter = new JsonApiMediaTypeFormatter(new JsonApiConfiguration()).GetPerRequestFormatterInstance(
+                typeof(string),
+                context.Request,
+                new MediaTypeHeaderValue(Constants.MediaType));
+
+            context.Response.Content = new ObjectContent(responseContent.ObjectType, responseContent.Value, formatter);
+        }
+    }
+}

--- a/Saule/Http/PreprocessingDelegatingHandler.cs
+++ b/Saule/Http/PreprocessingDelegatingHandler.cs
@@ -69,27 +69,8 @@ namespace Saule.Http
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var result = await base.SendAsync(request, cancellationToken);
-            var hasMediaType = request.Headers.Accept.Any(x => x.MediaType == Constants.MediaType);
 
-            var statusCode = (int)result.StatusCode;
-            if (!hasMediaType || (statusCode >= 400 && statusCode < 500))
-            {
-                // probably malformed request or not found
-                return result;
-            }
-
-            var value = result.Content as ObjectContent;
-
-            var content = PreprocessRequest(value?.Value, request, _config);
-
-            if (content.ErrorContent != null)
-            {
-                result.StatusCode = ApiError.IsClientError(content.ErrorContent)
-                    ? HttpStatusCode.BadRequest
-                    : HttpStatusCode.InternalServerError;
-            }
-
-            request.Properties.Add(Constants.PropertyNames.PreprocessResult, content);
+            JsonApiProcessor.ProcessRequest(request, result, _config, requiresMediaType: true);
 
             return result;
         }

--- a/Saule/Saule.csproj
+++ b/Saule/Saule.csproj
@@ -66,6 +66,7 @@
     <Compile Include="ApiResource.cs" />
     <Compile Include="Http\HandlesQueryAttribute.cs" />
     <Compile Include="Http\JsonApiAttribute.cs" />
+    <Compile Include="Http\JsonApiProcessor.cs" />
     <Compile Include="Http\JsonApiQueryValueProvider.cs" />
     <Compile Include="Http\JsonApiQueryValueProviderFactory.cs" />
     <Compile Include="JsonApiSerializerOfT.cs" />

--- a/Saule/Saule.csproj
+++ b/Saule/Saule.csproj
@@ -65,6 +65,7 @@
   <ItemGroup>
     <Compile Include="ApiResource.cs" />
     <Compile Include="Http\HandlesQueryAttribute.cs" />
+    <Compile Include="Http\JsonApiAttribute.cs" />
     <Compile Include="Http\JsonApiQueryValueProvider.cs" />
     <Compile Include="Http\JsonApiQueryValueProviderFactory.cs" />
     <Compile Include="JsonApiSerializerOfT.cs" />

--- a/Tests/Controllers/CompaniesController.cs
+++ b/Tests/Controllers/CompaniesController.cs
@@ -38,6 +38,16 @@ namespace Tests.Controllers
         }
 
         [HttpGet]
+        [JsonApi]
+        [Paginated(PerPage = 12)]
+        [Route("v2/companies")]
+        [ReturnsResource(typeof(CompanyResource))]
+        public IEnumerable<Company> GetCompaniesV2()
+        {
+            return Get.Companies(100);
+        }
+
+        [HttpGet]
         [Paginated(PerPage = 12)]
         [Route("companies/querypagesize")]
         [ReturnsResource(typeof(CompanyResource))]

--- a/Tests/Helpers/ObsoleteSetupJsonApiServer.cs
+++ b/Tests/Helpers/ObsoleteSetupJsonApiServer.cs
@@ -22,7 +22,6 @@ namespace Tests.Helpers
         internal ObsoleteSetupJsonApiServer(JsonApiMediaTypeFormatter formatter)
         {
             var config = new HttpConfiguration();
-            config.Formatters.Clear();
             config.Formatters.Add(formatter);
             config.MapHttpAttributeRoutes(new DefaultDirectRouteProvider());
 

--- a/Tests/Integration/ContentNegotiationTests.cs
+++ b/Tests/Integration/ContentNegotiationTests.cs
@@ -1,10 +1,8 @@
 ﻿using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using Saule;
 using Saule.Http;
 using Tests.Helpers;
@@ -24,6 +22,23 @@ namespace Tests.Integration
             public ObsoleteSetup(ObsoleteSetupJsonApiServer server)
             {
                 _server = server;
+            }
+
+            [Fact(DisplayName = "Servers MUST not respond with json api unless requested Content-Type is 'application/vnd.api+json' or action filter is set to 'JsonApiAttribute'")]
+            public async Task MustNotReturnJsonApiResponse()
+            {
+                var target = _server.GetClient();
+
+                var result = await target.GetAsync("api/companies/");
+                Assert.Equal("application/vnd.api+json", result.Content.Headers.ContentType.MediaType);
+
+                target.DefaultRequestHeaders.Clear();
+
+                result = await target.GetAsync("api/companies/");
+                Assert.Equal("application/json", result.Content.Headers.ContentType.MediaType);
+
+                result = await target.GetAsync("api/v2/companies/");
+                Assert.Equal("application/vnd.api+json", result.Content.Headers.ContentType.MediaType);
             }
 
             [Theory(DisplayName = "Servers MUST return content type 'application/vnd.api+json'")]


### PR DESCRIPTION
For existing WebApi projects, that don't use JsonApi/Saule we need a way to preserve backwards compatibility and opt into JsonApi on a case by case basis.

For example: `api/v2/companies` uses the attribute filter `JsonApi` which configures it to return a JsonAPI response instead of the default response.

<kbd>![image](https://user-images.githubusercontent.com/2644202/38332360-6a424d46-381b-11e8-897c-cc5a95f2c3fd.png)</kbd>


With this change, it's not necessary to call `ConfigureJsonApi` during application startup:

<kbd>![image](https://user-images.githubusercontent.com/2644202/38332266-32ca5b56-381b-11e8-9fe9-102158803fdb.png)</kbd>
