### PR TITLE
properly throw exceptions when using JsonApi attribute filter

### DIFF
--- a/Saule/Http/JsonApiAttribute.cs
+++ b/Saule/Http/JsonApiAttribute.cs
@@ -17,12 +17,13 @@ namespace Saule.Http
         public override void OnActionExecuted(HttpActionExecutedContext context)
         {
             var config = new JsonApiConfiguration();
-            JsonApiProcessor.ProcessRequest(context.Request, context.Response, config, requiresMediaType: false);
 
             if (context.Exception != null)
             {
-                return;
+                throw context.Exception;
             }
+
+            JsonApiProcessor.ProcessRequest(context.Request, context.Response, config, requiresMediaType: false);
 
             var responseContent = context.Response.Content as ObjectContent;
             if (responseContent == null)


### PR DESCRIPTION
If a webApi method throws an exception the `context.Response` [here](https://github.com/joukevandermaas/saule/blob/master/Saule/Http/JsonApiAttribute.cs#L20) will be null which throws a NullReferenceException masking the underlying exception.  This PR fixes this problem.