### PR TITLE
added LinkType.Top enum, so we can specify only top level links

### DIFF
--- a/Saule/LinkType.cs
+++ b/Saule/LinkType.cs
@@ -24,9 +24,9 @@ namespace Saule
         Related = 2,
 
         /// <summary>
-        /// Only top section links
+        /// Only self links in the top section
         /// </summary>
-        Top = 4,
+        TopSelf = 4,
 
         /// <summary>
         /// Generate all possible links

--- a/Saule/LinkType.cs
+++ b/Saule/LinkType.cs
@@ -24,6 +24,11 @@ namespace Saule
         Related = 2,
 
         /// <summary>
+        /// Only top section links
+        /// </summary>
+        Top = 4,
+
+        /// <summary>
         /// Generate all possible links
         /// </summary>
         All = ~None

--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -130,10 +130,8 @@ namespace Saule.Serialization
         {
             var result = new JObject();
 
-            // if resource has Top only and not Self, then we render it.
-            // otherwise to preserve back compatibility if Self is enabled, then we also render it
-            if ((_resource.LinkType.HasFlag(LinkType.Top) && !_resource.LinkType.HasFlag(LinkType.Self))
-                || _resource.LinkType.HasFlag(LinkType.Self))
+            // to preserve back compatibility if Self is enabled, then we also render it. Or if TopSelf is enabled
+            if (_resource.LinkType.HasFlag(LinkType.TopSelf) || _resource.LinkType.HasFlag(LinkType.Self))
             {
                 result.Add("self", _baseUrl);
             }

--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -130,7 +130,10 @@ namespace Saule.Serialization
         {
             var result = new JObject();
 
-            if (_resource.LinkType.HasFlag(LinkType.Self))
+            // if resource has Top only and not Self, then we render it.
+            // otherwise to preserve back compatibility if Self is enabled, then we also render it
+            if ((_resource.LinkType.HasFlag(LinkType.Top) && !_resource.LinkType.HasFlag(LinkType.Self))
+                || _resource.LinkType.HasFlag(LinkType.Self))
             {
                 result.Add("self", _baseUrl);
             }

--- a/Tests/Models/PersonOnlyTopLinksResource.cs
+++ b/Tests/Models/PersonOnlyTopLinksResource.cs
@@ -1,0 +1,23 @@
+﻿using Saule;
+
+namespace Tests.Models
+{
+    public class PersonOnlyTopLinksResource : ApiResource
+    {
+        public PersonOnlyTopLinksResource()
+        {
+            WithId(nameof(Person.Identifier));
+            WithLinks(LinkType.Top);
+
+            Attribute(nameof(Person.FirstName));
+            Attribute(nameof(Person.LastName));
+            Attribute(nameof(Person.Age));
+            Attribute(nameof(Person.Address));
+
+            BelongsTo<CompanyResource>(nameof(Person.Job), "/employer");
+            BelongsTo<CarResource>(nameof(Person.Car));
+            HasMany<PersonResource>(nameof(Person.Friends));
+            HasMany<PersonResource>( nameof( Person.FamilyMembers));
+        }
+    }
+}

--- a/Tests/Models/PersonOnlyTopLinksResource.cs
+++ b/Tests/Models/PersonOnlyTopLinksResource.cs
@@ -7,7 +7,7 @@ namespace Tests.Models
         public PersonOnlyTopLinksResource()
         {
             WithId(nameof(Person.Identifier));
-            WithLinks(LinkType.Top);
+            WithLinks(LinkType.TopSelf);
 
             Attribute(nameof(Person.FirstName));
             Attribute(nameof(Person.LastName));

--- a/Tests/Serialization/UrlConstructionTests.cs
+++ b/Tests/Serialization/UrlConstructionTests.cs
@@ -85,10 +85,10 @@ namespace Tests.Serialization
             Assert.Equal("/api/people/123", selfLink);
         }
 
-        [Fact(DisplayName = "Adds top level self link if only LinkType.Top is specified")]
+        [Fact(DisplayName = "Adds top level self link if only LinkType.TopSelf is specified")]
         public void TopLinkOnlyLink()
         {
-            var target = new ResourceSerializer(Get.Person(), new PersonOnlyTopLinksResource(),
+            var target = new ResourceSerializer(Get.People(1), new PersonOnlyTopLinksResource(),
                 GetUri("123"), DefaultPathBuilder, null, null, null);
             var result = target.Serialize();
             _output.WriteLine(result.ToString());
@@ -97,7 +97,7 @@ namespace Tests.Serialization
 
             Assert.Equal("/api/people/123", selfLink);
 
-            Assert.Null(result["data"]["links"]);
+            Assert.Null(result["data"][0]["links"]);
         }
 
         [Fact(DisplayName = "Omits top level links if so requested")]

--- a/Tests/Serialization/UrlConstructionTests.cs
+++ b/Tests/Serialization/UrlConstructionTests.cs
@@ -85,6 +85,21 @@ namespace Tests.Serialization
             Assert.Equal("/api/people/123", selfLink);
         }
 
+        [Fact(DisplayName = "Adds top level self link if only LinkType.Top is specified")]
+        public void TopLinkOnlyLink()
+        {
+            var target = new ResourceSerializer(Get.Person(), new PersonOnlyTopLinksResource(),
+                GetUri("123"), DefaultPathBuilder, null, null, null);
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            var selfLink = result["links"].Value<Uri>("self").AbsolutePath;
+
+            Assert.Equal("/api/people/123", selfLink);
+
+            Assert.Null(result["data"]["links"]);
+        }
+
         [Fact(DisplayName = "Omits top level links if so requested")]
         public void NoTopLevelLinks()
         {

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Models\PersonJobOnlyRelatedLinksResource.cs" />
     <Compile Include="Models\PersonJobOnlySelfLinksResource.cs" />
     <Compile Include="Models\PersonNoJobLinksResource.cs" />
+    <Compile Include="Models\PersonOnlyTopLinksResource.cs" />
     <Compile Include="Models\PersonNoLinksResource.cs" />
     <Compile Include="Models\PersonWithCompanyWithCustomersResource.cs" />
     <Compile Include="Models\PersonWithGuidAsRelationsResource.cs" />


### PR DESCRIPTION
Hi Jouke,

It's a PR for #201 item. I tried to preserve back compatibility and all existing tests are passing fine. I also added new one to test Top only scenario.

Thanks