### PR TITLE
Added logic to still return HttpErrors if there are more than one and if endpoint\controller doesn't have specified ReturnsResource

### DIFF
--- a/Saule/Http/PreprocessingDelegatingHandler.cs
+++ b/Saule/Http/PreprocessingDelegatingHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
@@ -41,11 +42,12 @@ namespace Saule.Http
             PrepareQueryContext(jsonApi, request, config);
 
             ApiResource resource = null;
+            bool isHttpError = content is HttpError || content is IEnumerable<HttpError>;
             if (request.Properties.ContainsKey(Constants.PropertyNames.ResourceDescriptor))
             {
                 resource = (ApiResource)request.Properties[Constants.PropertyNames.ResourceDescriptor];
             }
-            else if (content != null && !(content is HttpError))
+            else if (content != null && !isHttpError)
             {
                 content = new JsonApiException(
                     ErrorType.Server,
@@ -55,7 +57,7 @@ namespace Saule.Http
                 };
             }
 
-            if (!(content is HttpError) && jsonApi.QueryContext?.Pagination?.PerPage > jsonApi.QueryContext?.Pagination?.PageSizeLimit)
+            if (!isHttpError && jsonApi.QueryContext?.Pagination?.PerPage > jsonApi.QueryContext?.Pagination?.PageSizeLimit)
             {
                 content = new JsonApiException(ErrorType.Client, "Page size exceeds page size limit for queries.");
             }

--- a/Tests/Controllers/BrokenController.cs
+++ b/Tests/Controllers/BrokenController.cs
@@ -48,6 +48,23 @@ namespace Tests.Controllers
         }
 
         [HttpGet]
+        [Route("api/broken/errorsNoResource")]
+        public HttpResponseMessage TwoErrorsNoResource()
+        {
+            return Request.CreateResponse(HttpStatusCode.BadRequest, new List<HttpError>()
+            {
+                new HttpError("Error 1")
+                {
+                    ExceptionType = "Type 1"
+                },
+                new HttpError("Error 2")
+                {
+                    ExceptionType = "Type 2"
+                }
+            });
+        }
+
+        [HttpGet]
         [Route("api/broken/error")]
         [ReturnsResource(typeof(PersonResource))]
         public HttpResponseMessage OneError()

--- a/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
+++ b/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
@@ -658,13 +658,16 @@ namespace Tests.Integration
             }
         }
 
-        [Fact(DisplayName = "Passes through two 4xx errors")]
-        public async Task PassesThroughTwoHttpErrors()
+        [Theory(DisplayName = "Passes through two 4xx errors")]
+        [InlineData("api/broken/errors")]
+        // Passes through two 4xx errors when endpoint doesn't have any Resource specified
+        [InlineData("api/broken/errorsNoResource")]
+        public async Task PassesThroughTwoHttpErrors(string url)
         {
             using (var server = new NewSetupJsonApiServer(new JsonApiConfiguration()))
             {
                 var client = server.GetClient();
-                var response = await client.GetFullJsonResponseAsync("api/broken/errors");
+                var response = await client.GetFullJsonResponseAsync(url);
                 var errors = response.Content["errors"];
 
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -674,25 +677,6 @@ namespace Tests.Integration
                 Assert.Equal("Error 2.", errors[1]["title"]);
                 Assert.Equal("Type 2", errors[1]["code"]);
            }
-        }
-
-
-        [Fact(DisplayName = "Passes through two 4xx errors when endpoint doesn't have any Resource specified")]
-        public async Task PassesThroughTwoHttpErrorsWhenNoResourceIsSpecified()
-        {
-            using (var server = new NewSetupJsonApiServer(new JsonApiConfiguration()))
-            {
-                var client = server.GetClient();
-                var response = await client.GetFullJsonResponseAsync("api/broken/errorsNoResource");
-                var errors = response.Content["errors"];
-
-                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-                Assert.Equal(2, errors.Count());
-                Assert.Equal("Error 1.", errors[0]["title"]);
-                Assert.Equal("Type 1", errors[0]["code"]);
-                Assert.Equal("Error 2.", errors[1]["title"]);
-                Assert.Equal("Type 2", errors[1]["code"]);
-            }
         }
 
         [Fact(DisplayName = "Passes through one 400 error")]

--- a/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
+++ b/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
@@ -676,6 +676,25 @@ namespace Tests.Integration
            }
         }
 
+
+        [Fact(DisplayName = "Passes through two 4xx errors when endpoint doesn't have any Resource specified")]
+        public async Task PassesThroughTwoHttpErrorsWhenNoResourceIsSpecified()
+        {
+            using (var server = new NewSetupJsonApiServer(new JsonApiConfiguration()))
+            {
+                var client = server.GetClient();
+                var response = await client.GetFullJsonResponseAsync("api/broken/errorsNoResource");
+                var errors = response.Content["errors"];
+
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                Assert.Equal(2, errors.Count());
+                Assert.Equal("Error 1.", errors[0]["title"]);
+                Assert.Equal("Type 1", errors[0]["code"]);
+                Assert.Equal("Error 2.", errors[1]["title"]);
+                Assert.Equal("Type 2", errors[1]["code"]);
+            }
+        }
+
         [Fact(DisplayName = "Passes through one 400 error")]
         public async Task PassesThroughHttpError()
         {


### PR DESCRIPTION
Hi Jouke,

Looks like i had an issue last time when i added logic to support case when more than one HttpError is returned. If controller\action doesn't have ReturnResource then for just one HttpError it will work fine and will return that error. But for the list of httpErrors it will try to use ReturnResource. It works fine as deeper it still will use ErrorSerializer, but there is one case that doesn't work.

We have base controller that has some custom attributes, and all controllers inherit it. So base one doesn't have any ReturnResource attributes. But we have some some generic handling there and we can return more than one HttpError there and without that change it just throws an error that ReturnResource is missing

I added logic to check for both HttpError and IEnumerable<HttpError> and also added unit test to cover that scenario.

Thanks