### PR TITLE
Allow attributes on class

### DIFF
--- a/Saule/Http/AllowsQueryAttribute.cs
+++ b/Saule/Http/AllowsQueryAttribute.cs
@@ -15,7 +15,7 @@ namespace Saule.Http
     /// If the collection implements <see cref="IQueryable{T}"/>, the query will be executed
     /// efficiently.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
     public sealed class AllowsQueryAttribute : ActionFilterAttribute
     {
         /// <summary>

--- a/Saule/Http/DisableDefaultIncludedAttribute.cs
+++ b/Saule/Http/DisableDefaultIncludedAttribute.cs
@@ -11,7 +11,7 @@ namespace Saule.Http
     /// This attribute is only relevant when requesting a resource without an
     /// explicit include parameter.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
     public sealed class DisableDefaultIncludedAttribute : ActionFilterAttribute
     {
         /// <summary>

--- a/Saule/Http/PaginatedAttribute.cs
+++ b/Saule/Http/PaginatedAttribute.cs
@@ -13,7 +13,7 @@ namespace Saule.Http
     /// Indicates that the returned collection must be paginated. If the collection
     /// implements <see cref="IQueryable{T}"/>, the query will be executed efficiently.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
     public sealed class PaginatedAttribute : ActionFilterAttribute
     {
         private int? _perPage;


### PR DESCRIPTION
I'd like to be able to specify DisableDefaultIncludedAttribute, AllowsQueryAttribute, and PaginatedAttribute at the class (ApiController) level so that all endpoints in a controller and any derived controllers share these settings. This is especially important for DisableDefaultIncludedAttribute, because accidentally including all related resources can have unknown performance implications.