### PR TITLE
used _baseUrl.AbsoluteUri instead of _baseUrl to avoid included port number in the self link

### DIFF
--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -132,7 +132,7 @@ namespace Saule.Serialization
 
             if (_resource.LinkType.HasFlag(LinkType.Self))
             {
-                result.Add("self", _baseUrl);
+                result.Add("self", _baseUrl.AbsoluteUri);
             }
 
             var queryStrings = new PaginationQuery(_paginationContext);

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -115,14 +115,14 @@ namespace Tests.Serialization
             var job = result["data"]["relationships"]["job"]["links"];
             var friends = result["data"]["relationships"]["friends"]["links"];
 
-            var self = result["links"]["self"].Value<Uri>().AbsolutePath;
+            var self = result["links"]["self"].Value<string>();
             var jobSelf = job["self"].Value<Uri>().AbsolutePath;
             var jobRelated = job["related"].Value<Uri>().AbsolutePath;
             var friendsSelf = friends["self"].Value<Uri>().AbsolutePath;
             var friendsRelated = friends["related"].Value<Uri>().AbsolutePath;
             var included = result["included"][0]["links"]["self"].Value<Uri>().AbsolutePath;
 
-            Assert.Equal("/api/people/abc", self);
+            Assert.EndsWith("/api/people/abc", self);
             Assert.Equal("/api/people/abc/relationships/employer/", jobSelf);
             Assert.Equal("/api/people/abc/employer/", jobRelated);
             Assert.Equal("/api/people/abc/relationships/friends/", friendsSelf);

--- a/Tests/Serialization/UrlConstructionTests.cs
+++ b/Tests/Serialization/UrlConstructionTests.cs
@@ -33,11 +33,11 @@ namespace Tests.Serialization
 
             var jobLinks = result["data"]?["relationships"]?["job"]?["links"];
 
-            var selfLink = result["links"].Value<Uri>("self")?.PathAndQuery;
+            var selfLink = result["links"].Value<string>("self");
             var jobSelfLink = jobLinks?.Value<Uri>("self")?.PathAndQuery;
             var jobRelationLink = jobLinks?.Value<Uri>("related")?.PathAndQuery;
 
-            Assert.Equal("/api/people/123?a=b&c=d", selfLink);
+            Assert.EndsWith("/api/people/123?a=b&c=d", selfLink);
             Assert.Equal("/api/people/123/relationships/employer/", jobSelfLink);
             Assert.Equal("/api/people/123/employer/", jobRelationLink);
         }
@@ -80,9 +80,22 @@ namespace Tests.Serialization
             var result = target.Serialize();
             _output.WriteLine(result.ToString());
 
-            var selfLink = result["links"].Value<Uri>("self").AbsolutePath;
+            var selfLink = result["links"].Value<string>("self");
 
-            Assert.Equal("/api/people/123", selfLink);
+            Assert.EndsWith("/api/people/123", selfLink);
+        }
+
+        [Fact(DisplayName = "Adds top level self link without any port")]
+        public void SelfLinkNoPort()
+        {
+            var target = new ResourceSerializer(Get.Person(), new PersonResource(),
+                new Uri("http://localhost:80/api/people/123"), DefaultPathBuilder, null, null, null);
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            var selfLink = result["links"].Value<string>("self");
+
+            Assert.Equal("http://localhost/api/people/123", selfLink);
         }
 
         [Fact(DisplayName = "Omits top level links if so requested")]

--- a/Tests/Serialization/UrlConstructionTests.cs
+++ b/Tests/Serialization/UrlConstructionTests.cs
@@ -106,9 +106,9 @@ namespace Tests.Serialization
             var result = target.Serialize();
             _output.WriteLine(result.ToString());
 
-            var selfLink = result["links"].Value<Uri>("self").AbsolutePath;
+            var selfLink = result["links"].Value<string>("self");
 
-            Assert.Equal("/api/people/123", selfLink);
+            Assert.EndsWith("/api/people/123", selfLink);
 
             Assert.Null(result["data"][0]["links"]);
         }


### PR DESCRIPTION
Hi Jouke,

This is small PR to fix one small issue. It happens for us only when we host it under IIS (Win10\WinServer 2016 and probably all others too).

The issue is that top self link always includes port even if port is standard like this:

```
    "links": {
        "self": "http://localhost:80/SauleExample/api/values"
    }
```

or like this
```
    "links": {
        "self": "https://localhost:443/SauleExample/api/values"
    }
```

It's still valid url as it can contain port, but it looks a bit weird. Somehow IIS always pushes port in the `Request.Url` and `_baseUrl.OriginalUrl` always has it, and when we pass Uri as object for serialization, then Newtonsoft.Json uses `.OriginalUrl` and it gives us 80\443 ports for regular http\https hosting.

I pushed change to use `_baseUri.AbsoluteUri` in the `ResourceSerializer` and also updated a couple of unit tests as they were using Uri from JObject but now it has just regular string. I also added unit test for `ResourceSerializer` to test this specific case. Also i verified that non standard ports still are displayed under IIS\IIS Express

Here is also screenshot of VisualStudio watch that shows current values during debug

![sauleexample_debug](https://user-images.githubusercontent.com/17708369/46674384-a66ddd00-cbe4-11e8-82d7-8d0195bee963.png)


Full response example before fix looks like it:

```
{
    "data": [
        {
            "type": "person",
            "id": "1",
            "links": {
                "self": "http://localhost/SauleExample/api/people/1/"
            },
            "attributes": {
                "name": "some person",
                "age": 42
            },
            "relationships": {
                "job": {
                    "links": {
                        "self": "http://localhost/SauleExample/api/people/1/relationships/job/",
                        "related": "http://localhost/SauleExample/api/people/1/job/"
                    },
                    "data": {
                        "type": "company",
                        "id": "11"
                    }
                }
            }
        }
    ],
    "links": {
        "self": "http://localhost:80/SauleExample/api/values"
    },
    "included": [
        {
            "type": "company",
            "id": "11",
            "links": {
                "self": "http://localhost/SauleExample/api/companies/11/"
            },
            "attributes": {
                "name": "Some company",
                "location": "some location"
            }
        }
    ]
}
```