### PR TITLE
Moved QueryContext action parameter initialization to more common place

### DIFF
--- a/Saule/Http/HandlesQueryAttribute.cs
+++ b/Saule/Http/HandlesQueryAttribute.cs
@@ -6,6 +6,7 @@ using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 using Saule.Queries;
+using Saule.Queries.Fieldset;
 using Saule.Queries.Filtering;
 using Saule.Queries.Including;
 using Saule.Queries.Sorting;
@@ -33,6 +34,7 @@ namespace Saule.Http
             queryContext.IsHandledQuery = true;
             queryContext.Sort = new SortContext(queryParams);
             queryContext.Filter = new FilterContext(queryParams);
+            queryContext.Fieldset = new FieldsetContext(queryParams);
 
             if (queryContext.Include == null)
             {
@@ -41,17 +43,6 @@ namespace Saule.Http
             else
             {
                 queryContext.Include.SetIncludes(queryParams);
-            }
-
-            // we validate if action has QueryContext parameter
-            // and if it has it, then we pass it
-            var parameters = actionContext.ActionDescriptor.GetParameters();
-            foreach (var parameter in parameters)
-            {
-                if (parameter.ParameterType == typeof(QueryContext))
-                {
-                    actionContext.ActionArguments[parameter.ParameterName] = queryContext;
-                }
             }
 
             base.OnActionExecuting(actionContext);

--- a/Saule/Http/QueryContextUtils.cs
+++ b/Saule/Http/QueryContextUtils.cs
@@ -19,6 +19,17 @@ namespace Saule.Http
             {
                 query = new QueryContext();
                 actionContext.Request.Properties.Add(Constants.PropertyNames.QueryContext, query);
+
+                // we validate if action has QueryContext parameter
+                // and if it has it, then we pass it
+                var parameters = actionContext.ActionDescriptor.GetParameters();
+                foreach (var parameter in parameters)
+                {
+                    if (parameter.ParameterType == typeof(QueryContext))
+                    {
+                        actionContext.ActionArguments[parameter.ParameterName] = query;
+                    }
+                }
             }
 
             return query;


### PR DESCRIPTION
Hi Jouke,

We had a case when WebApi action has `ObjectContext` parameter and then `HandlesQuery` attribute passes current `ObjectContext` value as paramter. So endpoint can consume\handle current context.

I did two changes there:
1. I moved that code that initialize `ObjectContext` in action's parameter to more common place `QueryContextUtils` so now it will be available to any action that needs it, and not only by action that has `HandlesQuery`. So if endpoint with `AllowsQuery` wants to get current context for logging\other reasons, then it can get it

2. I also added `Fieldset` initialization to `HandlesQuery` so now it also can use `fields` logic too. As before that it would ignore it and `ObjectContext` won't parse actual `Fieldset` value