### PR TITLE
Fixed issue with encoding for `links.self` item

### DIFF
--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -133,7 +133,7 @@ namespace Saule.Serialization
             // to preserve back compatibility if Self is enabled, then we also render it. Or if TopSelf is enabled
             if (_resource.LinkType.HasFlag(LinkType.TopSelf) || _resource.LinkType.HasFlag(LinkType.Self))
             {
-                result.Add("self", _baseUrl.AbsoluteUri);
+                result.Add("self", _baseUrl.ToString());
             }
 
             var queryStrings = new PaginationQuery(_paginationContext, _value);

--- a/Tests/Serialization/UrlConstructionTests.cs
+++ b/Tests/Serialization/UrlConstructionTests.cs
@@ -98,6 +98,45 @@ namespace Tests.Serialization
             Assert.Equal("http://localhost/api/people/123", selfLink);
         }
 
+        [Fact(DisplayName = "Adds top level self link without any port for https")]
+        public void SelfLinkNoPortHttps()
+        {
+            var target = new ResourceSerializer(Get.Person(), new PersonResource(),
+                new Uri("https://localhost:443/api/people/123"), DefaultPathBuilder, null, null, null);
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            var selfLink = result["links"].Value<string>("self");
+
+            Assert.Equal("https://localhost/api/people/123", selfLink);
+        }
+
+        [Fact(DisplayName = "Adds top level self link without any port and with correct encoding")]
+        public void SelfLinkNoEncoding()
+        {
+            var target = new ResourceSerializer(Get.Person(), new PersonResource(),
+                new Uri("https://localhost:443/api/people?page[number]=1&page[size]=10"), DefaultPathBuilder, null, null, null);
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            var selfLink = result["links"].Value<string>("self");
+
+            Assert.Equal("https://localhost/api/people?page[number]=1&page[size]=10", selfLink);
+        }
+
+        [Fact(DisplayName = "Adds top level self link without any port and with correct encoding based on already encoded value")]
+        public void SelfLinkNoEncodingBasedOnEncoded()
+        {
+            var target = new ResourceSerializer(Get.Person(), new PersonResource(),
+                new Uri("https://localhost:443/api/people?page%5Bnumber%5D=1&page%5Bsize%5D=10"), DefaultPathBuilder, null, null, null);
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            var selfLink = result["links"].Value<string>("self");
+
+            Assert.Equal("https://localhost/api/people?page[number]=1&page[size]=10", selfLink);
+        }
+
         [Fact(DisplayName = "Adds top level self link if only LinkType.TopSelf is specified")]
         public void TopLinkOnlyLink()
         {


### PR DESCRIPTION
Hi Jouke,

It's a follow up for already merged PR #206 . After we started to use paging, we found one issue with that old one PR. If initial query has parameters like `page[number]`, etc, then it WebApi might encode them and then `HttpRequestMessage.RequestUri` would have already encoded one, and then `links.self` would have encoded value. 

Here is what we are getting for endpoint that supports paging when we access such endpoint - https://localhost/WebService4/v5/internal/locations/marketplace?page[number]=2

```
{
    "data": [
        {
            "type": "marketplace-location",
            "id": "6927",
            "links": {
                "self": "https://localhost/WebService4/v5/internal/locations/locations/marketplace/6927/"
            },
            "attributes": {
                ...
            }
        }
    ],
    "links": {
        "self": "https://localhost/WebService4/v5/internal/locations/marketplace?page%5Bnumber%5D=1",
        "first": "https://localhost/WebService4/v5/internal/locations/marketplace?page[number]=0",
        "next": "https://localhost/WebService4/v5/internal/locations/marketplace?page[number]=2",
        "prev": "https://localhost/WebService4/v5/internal/locations/marketplace?page[number]=0",
        "last": "https://localhost/WebService4/v5/internal/locations/marketplace?page[number]=12"
    }
}
```

Here is what i'm seeing in Visual Studio in the debugger. I'm not sure why it happens in that way as initial url it totally correct and doesn't have any encoding.

![image](https://user-images.githubusercontent.com/17708369/67395933-7014bd00-f5af-11e9-9191-c0e633b935a9.png)

I pushed fix to use `_baseUrl.ToString()` so it won't do encoding there and port also won't be present. And added a couple of tests to validate it. The problem there is that in unit test it doesn't do that so it's hard to mimic that behavior and only way i was able to do it by specifying already encoded `_baseUrl` in `UrlConstructionTests.SelfLinkNoEncodingBasedOnEncoded` unit test.

Thanks!