### PR TITLE
Fixed `links.prev` logic if first page number isn't zero

### DIFF
--- a/Saule/Queries/Pagination/PaginationQuery.cs
+++ b/Saule/Queries/Pagination/PaginationQuery.cs
@@ -28,7 +28,7 @@ namespace Saule.Queries.Pagination
 
             FirstPage = CreateQueryString(context.ClientFilters, context.FirstPageNumber);
             NextPage = CreateQueryString(context.ClientFilters, isNumber ? page + 1 : context.FirstPageNumber + 1);
-            PreviousPage = isNumber && page > 0
+            PreviousPage = isNumber && page > context.FirstPageNumber
                 ? CreateQueryString(context.ClientFilters, page - 1)
                 : null;
             if (context.TotalResultsCount.HasValue && context.PerPage.GetValueOrDefault(0) != 0)

--- a/Tests/Serialization/UrlConstructionTests.cs
+++ b/Tests/Serialization/UrlConstructionTests.cs
@@ -211,7 +211,7 @@ namespace Tests.Serialization
             var people = Get.People(5);
             var target = new ResourceSerializer(people, new PersonResource(),
                 GetUri(), DefaultPathBuilder,
-                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "1"), pageSizeDefault: 10, null, firstPageNumber:1), null, null);
+                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "1"), pageSizeDefault: 10, pageSizeLimit:null, firstPageNumber:1), null, null);
             var result = target.Serialize();
             _output.WriteLine(result.ToString());
 
@@ -219,7 +219,7 @@ namespace Tests.Serialization
 
             target = new ResourceSerializer(people, new PersonResource(),
                 GetUri(), DefaultPathBuilder,
-                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "2"), pageSizeDefault: 10, null, firstPageNumber: 1), null, null);
+                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "2"), pageSizeDefault: 10, pageSizeLimit:null, firstPageNumber: 1), null, null);
             result = target.Serialize();
 
             var nextLink = Uri.UnescapeDataString(result["links"].Value<Uri>("prev").Query);

--- a/Tests/Serialization/UrlConstructionTests.cs
+++ b/Tests/Serialization/UrlConstructionTests.cs
@@ -205,6 +205,28 @@ namespace Tests.Serialization
             Assert.Equal("?page[number]=0", nextLink);
         }
 
+        [Fact(DisplayName = "Adds previous link with shifted first page number and only if needed")]
+        public void PreviousLinkWithShiftedFirstPage()
+        {
+            var people = Get.People(5);
+            var target = new ResourceSerializer(people, new PersonResource(),
+                GetUri(), DefaultPathBuilder,
+                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "1"), pageSizeDefault: 10, null, firstPageNumber:1), null, null);
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            Assert.Equal(null, result["links"]["prev"]);
+
+            target = new ResourceSerializer(people, new PersonResource(),
+                GetUri(), DefaultPathBuilder,
+                new PaginationContext(GetQuery(Constants.QueryNames.PageNumber, "2"), pageSizeDefault: 10, null, firstPageNumber: 1), null, null);
+            result = target.Serialize();
+
+            var nextLink = Uri.UnescapeDataString(result["links"].Value<Uri>("prev").Query);
+            Assert.Equal("?page[number]=1", nextLink);
+        }
+
+
         [Fact(DisplayName = "Keeps other query parameters when paginating")]
         public void PaginationQueryParams()
         {


### PR DESCRIPTION
Hi Jouke,

We found one missing case in initial pagination request. When we have FirstPage as `1`, then we shouldn't generate `links.prev` if current page is `1`. Like in example below `prev` link shouldn't be present as first page is `1`

```
    "links": {
        "self": "https://localhost/WebService4/v5/internal/locations/marketplace?page[number]=1",
        "first": "https://localhost/WebService4/v5/internal/locations/marketplace?page[number]=1",
        "next": "https://localhost/WebService4/v5/internal/locations/marketplace?page[number]=2",
        "prev": "https://localhost/WebService4/v5/internal/locations/marketplace?page[number]=0",
        "last": "https://localhost/WebService4/v5/internal/locations/marketplace?page[number]=12"
    }
```
I added unit test to cover that scenario and sorry for initially missed case :) 

Thanks!