### PR TITLE
Fixed pagination when endpoint uses custom PagedResult<T> type

### DIFF
--- a/Saule/Queries/Pagination/PagedResultQuery.cs
+++ b/Saule/Queries/Pagination/PagedResultQuery.cs
@@ -37,13 +37,20 @@ namespace Saule.Queries.Pagination
                 return false;
             }
 
-            if (!obj.GetType().IsGenericType
-                || obj.GetType().GetGenericTypeDefinition() != typeof(PagedResult<>))
+            // we need to check the whole hierarchy of classes
+            var type = obj.GetType();
+            while (type != null)
             {
-                return false;
+                if (type.IsGenericType
+                    && type.GetGenericTypeDefinition() == typeof(PagedResult<>))
+                {
+                    return true;
+                }
+
+                type = type.BaseType;
             }
 
-            return true;
+            return false;
         }
 
         private static object UnwrapPagedResult(object obj)

--- a/Tests/Controllers/CompaniesController.cs
+++ b/Tests/Controllers/CompaniesController.cs
@@ -90,6 +90,19 @@ namespace Tests.Controllers
         }
 
         [HttpGet]
+        [Paginated(PerPage = 20, PageSizeLimit = 20)]
+        [Route("companies/paged-result-custom")]
+        [ReturnsResource(typeof(CompanyResource))]
+        public PagedResult<Company> GetCompaniesWithCustomPaging()
+        {
+            return new CustomPagedResult<Company>()
+            {
+                TotalResultsCount = 100,
+                Data = Get.Companies(100).ToList()
+            };
+        }
+
+        [HttpGet]
         [Paginated(PerPage = 20, PageSizeLimit = 20, FirstPageNumber = 1)]
         [Route("companies/paged-result-first-page")]
         [ReturnsResource(typeof(CompanyResource))]

--- a/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
+++ b/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
@@ -434,6 +434,7 @@ namespace Tests.Integration
         }
 
         [InlineData("api/companies/paged-result", 0)]
+        [InlineData("api/companies/paged-result-custom", 0)]
         [InlineData("api/companies/paged-result-first-page", 1)]
         [Theory(DisplayName = "Paged result calculates page counts")]
         public async Task PagedResult(object baseUrl, int firstPageNumber)

--- a/Tests/Models/CustomPagedResult.cs
+++ b/Tests/Models/CustomPagedResult.cs
@@ -1,0 +1,9 @@
+﻿using Saule.Queries.Pagination;
+
+namespace Tests.Models
+{
+    public class CustomPagedResult<T>: PagedResult<T>
+    {
+        public int IgnoredValue { get; set; }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Models\CompanyWithCustomersResource.cs" />
     <Compile Include="Models\Customer.cs" />
     <Compile Include="Models\CustomerResource.cs" />
+    <Compile Include="Models\CustomPagedResult.cs" />
     <Compile Include="Models\GuidAsRelation.cs" />
     <Compile Include="Models\GuidAsId.cs" />
     <Compile Include="Helpers\ObsoleteSetupJsonApiServer.cs" />


### PR DESCRIPTION
Hey Jouke,

Sorry, but it's another PR for another missing thing :) we tried to use custom PagedResult<T> class. We use it like 

```
	public class XPagedResult<T>: PagedResult<T>
	{
		public int? TotalPages { get; set; }
	}
```

And then for JSON.API it won't display TotalPages, but for regular JSON it will display that TotalPages field too plus properties in the base class. 

The problem is my initial code in `PagedResuleQuery.IsPagedResult` was checking for specific type but it should also check the base classes too. I've fixed it in this PR and added unit test to cover that scenario too

Thanks!