### PR TITLE
Fixed links.last when there are no any items in response

### DIFF
--- a/Saule/Queries/Pagination/PaginationQuery.cs
+++ b/Saule/Queries/Pagination/PaginationQuery.cs
@@ -35,7 +35,9 @@ namespace Saule.Queries.Pagination
             {
                 // we also should add firstPage as if it's not a zero, then total page count should be shifted based on firstPageNumber
                 // with 60 elements and 20 page size. if firstPage is 0, then lastPage should be 2. If firstPage is 1, then lastPage should be 3
-                var totalPages = (int)Math.Ceiling((double)context.TotalResultsCount / context.PerPage.Value) - 1 + context.FirstPageNumber;
+                int totalPages = context.TotalResultsCount == 0
+                    ? context.FirstPageNumber
+                    : (int)Math.Ceiling((double)context.TotalResultsCount / context.PerPage.Value) - 1 + context.FirstPageNumber;
                 LastPage = CreateQueryString(context.ClientFilters, totalPages);
             }
         }

--- a/Tests/Controllers/CompaniesController.cs
+++ b/Tests/Controllers/CompaniesController.cs
@@ -116,6 +116,32 @@ namespace Tests.Controllers
         }
 
         [HttpGet]
+        [Paginated(PerPage = 20, PageSizeLimit = 20, FirstPageNumber = 1)]
+        [Route("companies/paged-result-empty-first-page")]
+        [ReturnsResource(typeof(CompanyResource))]
+        public PagedResult<Company> GetEmpyCompaniesFirstPage()
+        {
+            return new PagedResult<Company>()
+            {
+                TotalResultsCount = 0,
+                Data = new List<Company>()
+            };
+        }
+
+        [HttpGet]
+        [Paginated(PerPage = 20, PageSizeLimit = 20)]
+        [Route("companies/paged-result-empty")]
+        [ReturnsResource(typeof(CompanyResource))]
+        public PagedResult<Company> GetEmpyCompanies()
+        {
+            return new PagedResult<Company>()
+            {
+                TotalResultsCount = 0,
+                Data = new List<Company>()
+            };
+        }
+
+        [HttpGet]
         [Paginated(PerPage = 20, PageSizeLimit = 20)]
         [Route("companies/paged-result-queryable")]
         [ReturnsResource(typeof(CompanyResource))]

--- a/Tests/Controllers/CompaniesController.cs
+++ b/Tests/Controllers/CompaniesController.cs
@@ -143,6 +143,33 @@ namespace Tests.Controllers
 
         [HttpGet]
         [Paginated(PerPage = 20, PageSizeLimit = 20)]
+        [Route("companies/paged-result-10items")]
+        [ReturnsResource(typeof(CompanyResource))]
+        public PagedResult<Company> GetCompaniesWith10Items()
+        {
+            return new PagedResult<Company>()
+            {
+                TotalResultsCount = 10,
+                Data = Get.Companies(10).ToList()
+            };
+        }
+
+
+        [HttpGet]
+        [Paginated(PerPage = 20, PageSizeLimit = 20, FirstPageNumber = 1)]
+        [Route("companies/paged-result-10items-first-page")]
+        [ReturnsResource(typeof(CompanyResource))]
+        public PagedResult<Company> GetCompaniesWith10ItemsAndFirstPage()
+        {
+            return new PagedResult<Company>()
+            {
+                TotalResultsCount = 10,
+                Data = Get.Companies(10).ToList()
+            };
+        }
+
+        [HttpGet]
+        [Paginated(PerPage = 20, PageSizeLimit = 20)]
         [Route("companies/paged-result-queryable")]
         [ReturnsResource(typeof(CompanyResource))]
         public IQueryable<Company> GetCompaniesWithPagingAndQueryable()

--- a/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
+++ b/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
@@ -541,6 +541,42 @@ namespace Tests.Integration
             }
         }
 
+        [InlineData("api/companies/paged-result-10items", 0)]
+        [InlineData("api/companies/paged-result-10items-first-page", 1)]
+        [Theory(DisplayName = "Paged result calculates correct first and last links when there items for less then full page")]
+        public async Task PagedResultOnePageResult(string baseUrl, int firstPageNumber)
+        {
+            int itemsCount = 10;
+            using (var server = new NewSetupJsonApiServer(new JsonApiConfiguration()))
+            {
+                var client = server.GetClient();
+                // endpoint will return just 10 items that should be less than the whole page
+                List<string> endpoints = new List<string>()
+                {
+                    baseUrl,
+                    // lets ask for different page to be sure that it still will have correct first and last
+                    $"{baseUrl}?page[number]=1",
+                    // then ask for custom pageSize
+                    $"{baseUrl}?page[number]=1&page[size]=15",
+                    // then for custom pageSize but without pageNumber
+                    $"{baseUrl}?page[size]=15"
+                };
+
+                foreach (var endpoint in endpoints)
+                {
+                    var result = await client.GetFullJsonResponseAsync($"{baseUrl}");
+                    var resultCount = ((JArray)result.Content["data"])?.Count;
+                    var last = result.Content["links"]["last"].Value<string>();
+                    var first = result.Content["links"]["first"].Value<string>();
+                    Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+                    Assert.Equal(itemsCount, resultCount);
+                    Assert.EndsWith($"{baseUrl}?page[number]={firstPageNumber}", first);
+                    Assert.EndsWith($"{baseUrl}?page[number]={firstPageNumber}", last);
+                    Assert.Null(result.Content["links"]["next"]);
+                }
+            }
+        }
+
         [Fact(DisplayName = "Applies sorting when appropriate")]
         public async Task AppliesSorting()
         {

--- a/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
+++ b/Tests/Integration/JsonApiMediaTypeFormatterTests.cs
@@ -506,6 +506,41 @@ namespace Tests.Integration
             }
         }
 
+        [InlineData("api/companies/paged-result-empty", 0)]
+        [InlineData("api/companies/paged-result-empty-first-page", 1)]
+        [Theory(DisplayName = "Paged result calculates correct first and last links when there are no any items in the response")]
+        public async Task PagedResultEmpty(string baseUrl, int firstPageNumber)
+        {
+            using (var server = new NewSetupJsonApiServer(new JsonApiConfiguration()))
+            {
+                var client = server.GetClient();
+                // endpoint will return empty result
+                List<string> endpoints = new List<string>()
+                {
+                    baseUrl,
+                    // lets ask for different page to be sure that it still will have correct first and last
+                    $"{baseUrl}?page[number]=3",
+                    // then ask for custom pageSize
+                    $"{baseUrl}?page[number]=3&page[size]=1",
+                    // then for custom pageSize but without pageNumber
+                    $"{baseUrl}?page[size]=1",
+                };
+
+                foreach (var endpoint in endpoints)
+                {
+                    var result = await client.GetFullJsonResponseAsync($"{baseUrl}");
+                    var resultCount = ((JArray)result.Content["data"])?.Count;
+                    var last = result.Content["links"]["last"].Value<string>();
+                    var first = result.Content["links"]["first"].Value<string>();
+                    Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+                    Assert.Equal(0, resultCount);
+                    Assert.EndsWith($"{baseUrl}?page[number]={firstPageNumber}", first);
+                    Assert.EndsWith($"{baseUrl}?page[number]={firstPageNumber}", last);
+                    Assert.Null(result.Content["links"]["next"]);
+                }
+            }
+        }
+
         [Fact(DisplayName = "Applies sorting when appropriate")]
         public async Task AppliesSorting()
         {


### PR DESCRIPTION
Hi Jouke,

Looks like we missed one more case initially. When endpoint doesn't return any items, then `links.last` will have incorrect result. 

If we would use `1` as first page number, then the response would be

```
{
  "data" : [ ],
  "links" : {
    "self" : "https://some/v5/equipment/",
    "first" : "https://some/v5/equipment/?page[number]=1",
    "last" : "https://some/v5/equipment/?page[number]=0"
  }
}
```

and `last` has `page[number]=0` that isn't correct and should be the same as `first`.
And if we don't have custom `firstPage` and by default it's `0`, then response would be

```
{
  "data" : [ ],
  "links" : {
    "self" : "https://some/v5/equipment/",
    "first" : "https://some/v5/equipment/?page[number]=1",
    "last" : "https://some/v5/equipment/?page[number]=-1"
  }
}
```
This PR is the fix for that logic and also a couple of unit tests to cover this scenario