### PR TITLE
Fix self generation for custom route with text IDs

### DIFF
--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -140,7 +140,7 @@ namespace Saule.Serialization
             // to preserve back compatibility if Self is enabled, then we also render it. Or if TopSelf is enabled
             if (_resource.LinkType.HasFlag(LinkType.TopSelf) || _resource.LinkType.HasFlag(LinkType.Self))
             {
-                if (id != null && !_baseUrl.AbsolutePath.EndsWith(id))
+                if (id != null && !_baseUrl.AbsolutePath.EndsWith(id, StringComparison.InvariantCultureIgnoreCase))
                 {
                     AddUrl(result, "self", _urlBuilder.BuildCanonicalPath(_resource, id));
                 }

--- a/Tests/Serialization/UrlConstructionTests.cs
+++ b/Tests/Serialization/UrlConstructionTests.cs
@@ -79,6 +79,28 @@ namespace Tests.Serialization
             }
         }
 
+        [Fact(DisplayName = "Self Link Single Resource Casing")]
+        public void SelfLinkSingleResourceCasing()
+        {
+            var person = new PersonWithDifferentId(false, "Allen");
+
+            var lowerTarget = new ResourceSerializer(person, new PersonWithDifferentIdResource(),
+                 GetUri("allen"), DefaultPathBuilder, null, null, null);
+            var upperTarget = new ResourceSerializer(person, new PersonWithDifferentIdResource(),
+                GetUri("Allen"), DefaultPathBuilder, null, null, null);
+
+            var lowerResult = lowerTarget.Serialize();
+            _output.WriteLine(lowerResult.ToString());
+            var upperResult = upperTarget.Serialize();
+            _output.WriteLine(upperResult.ToString());
+
+            var selfLinkLower = lowerResult["links"].Value<string>("self");
+            var selfLinkUpper = upperResult["links"].Value<string>("self");
+
+            Assert.EndsWith("/api/people/allen", selfLinkLower);
+            Assert.EndsWith("/api/people/Allen", selfLinkUpper);
+        }
+        
         [Fact(DisplayName = "Items have self links in a collection with custom route and top self link")]
         public void SelfLinksInCollectionCustomRoute()
         {


### PR DESCRIPTION
Found issue due to the change made here 

https://github.com/joukevandermaas/saule/pull/231

Due to using the `EndsWith` method, I missed the case where a user could be using a text based ID with different casing. While developing a new endpoint I saw that the ID was appended twice on the end of the URL.

Added Unit test to catch this in the future.

Solution

Added the `StringComparison.InvariantCultureIgnoreCase` argument to the endswith logic.