### PR TITLE
Add JsonConverter Functionality On Serialization

### DIFF
--- a/Saule/JsonApiSerializer.cs
+++ b/Saule/JsonApiSerializer.cs
@@ -95,6 +95,17 @@ namespace Saule
             return result;
         }
 
+        internal static JsonSerializer GetJsonSerializer(IEnumerable<JsonConverter> converters)
+        {
+            var serializer = new JsonSerializer { ReferenceLoopHandling = ReferenceLoopHandling.Ignore };
+            foreach (var converter in converters)
+            {
+                serializer.Converters.Add(converter);
+            }
+
+            return serializer;
+        }
+
         private static List<ApiError> GetAsError(object @object)
         {
             var exception = @object as Exception;
@@ -116,17 +127,6 @@ namespace Saule
             }
 
             return null;
-        }
-
-        private static JsonSerializer GetJsonSerializer(IEnumerable<JsonConverter> converters)
-        {
-            var serializer = new JsonSerializer { ReferenceLoopHandling = ReferenceLoopHandling.Ignore };
-            foreach (var converter in converters)
-            {
-                serializer.Converters.Add(converter);
-            }
-
-            return serializer;
         }
     }
 }

--- a/Saule/Saule.csproj
+++ b/Saule/Saule.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Serialization\CamelCasePropertyNameConverter.cs" />
     <Compile Include="Serialization\DefaultPropertyNameConverter.cs" />
     <Compile Include="Serialization\IPropertyNameConverter.cs" />
+    <Compile Include="Serialization\SourceContractResolver.cs" />
     <Compile Include="StringDictionaryExtensions.cs" />
     <Compile Include="FormatterPriority.cs" />
     <Compile Include="Http\DisableDefaultIncludedAttribute.cs" />

--- a/Saule/Serialization/JsonApiContractResolver.cs
+++ b/Saule/Serialization/JsonApiContractResolver.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -9,30 +8,15 @@ namespace Saule.Serialization
     internal class JsonApiContractResolver : DefaultContractResolver
     {
         private readonly IPropertyNameConverter _nameConverter;
-        private readonly ApiResource _apiResource;
-        private int _depth;
-
-        public JsonApiContractResolver(IPropertyNameConverter nameConverter, ApiResource apiResource)
-            : this(nameConverter)
-        {
-            _apiResource = apiResource;
-        }
 
         public JsonApiContractResolver(IPropertyNameConverter nameConverter)
         {
             _nameConverter = nameConverter;
-            _depth = 0;
         }
 
         protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
         {
             var properties = base.CreateProperties(type, memberSerialization);
-
-            if (_apiResource != null && _depth == 0)
-            {
-                // Only filter out properties at the root level and when given a api resource that list needed field
-                properties = properties.Where(property => _apiResource.Attributes.Any(att => att.PropertyName == property.PropertyName)).ToList();
-            }
 
             foreach (var property in properties)
             {
@@ -40,16 +24,6 @@ namespace Saule.Serialization
             }
 
             return properties;
-        }
-
-        protected override JsonContract CreateContract(Type objectType)
-        {
-            var contract = base.CreateContract(objectType);
-
-            contract.OnSerializingCallbacks.Add((obj, context) => { _depth++; });
-            contract.OnSerializedCallbacks.Add((obj, context) => { _depth--; });
-
-            return contract;
         }
     }
 }

--- a/Saule/Serialization/JsonApiContractResolver.cs
+++ b/Saule/Serialization/JsonApiContractResolver.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -8,15 +9,30 @@ namespace Saule.Serialization
     internal class JsonApiContractResolver : DefaultContractResolver
     {
         private readonly IPropertyNameConverter _nameConverter;
+        private readonly ApiResource _apiResource;
+        private int _depth;
+
+        public JsonApiContractResolver(IPropertyNameConverter nameConverter, ApiResource apiResource)
+            : this(nameConverter)
+        {
+            _apiResource = apiResource;
+        }
 
         public JsonApiContractResolver(IPropertyNameConverter nameConverter)
         {
             _nameConverter = nameConverter;
+            _depth = 0;
         }
 
         protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
         {
             var properties = base.CreateProperties(type, memberSerialization);
+
+            if (_apiResource != null && _depth == 0)
+            {
+                // Only filter out properties at the root level and when given a api resource that list needed field
+                properties = properties.Where(property => _apiResource.Attributes.Any(att => att.PropertyName == property.PropertyName)).ToList();
+            }
 
             foreach (var property in properties)
             {
@@ -24,6 +40,16 @@ namespace Saule.Serialization
             }
 
             return properties;
+        }
+
+        protected override JsonContract CreateContract(Type objectType)
+        {
+            var contract = base.CreateContract(objectType);
+
+            contract.OnSerializingCallbacks.Add((obj, context) => { _depth++; });
+            contract.OnSerializedCallbacks.Add((obj, context) => { _depth--; });
+
+            return contract;
         }
     }
 }

--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -292,6 +292,7 @@ namespace Saule.Serialization
 
         private JObject SerializeAttributes(ResourceGraphNode node)
         {
+            // The source serializer uses a SourceContractResolver to ensure that we only serialize the properties needed
             var serializedSourceObject = JObject.FromObject(node.SourceObject, _sourceSerializer);
             var attributeHash = node.Resource.Attributes
                 .Where(a =>
@@ -312,6 +313,7 @@ namespace Saule.Serialization
 
         private JObject SerializeAttributes(ResourceGraphNode node, FieldsetProperty fieldset)
         {
+            // The source serializer uses a SourceContractResolver to ensure that we only serialize the properties needed
             var serializedSourceObject = JObject.FromObject(node.SourceObject, _sourceSerializer);
             var attributeHash = node.Resource.Attributes
                 .Where(a =>

--- a/Saule/Serialization/SourceContractResolver.cs
+++ b/Saule/Serialization/SourceContractResolver.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Saule.Serialization
+{
+    internal class SourceContractResolver : DefaultContractResolver
+    {
+        private readonly IPropertyNameConverter _nameConverter;
+        private readonly ApiResource _apiResource;
+        private int _depth;
+
+        public SourceContractResolver(IPropertyNameConverter nameConverter, ApiResource apiResource)
+        {
+            _apiResource = apiResource;
+            _nameConverter = nameConverter;
+            _depth = 0;
+        }
+
+        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+        {
+            var properties = base.CreateProperties(type, memberSerialization);
+
+            if (_apiResource != null && _depth == 0)
+            {
+                // Only filter out properties at the root level and when given a api resource that list needed field
+                properties = properties.Where(property => _apiResource.Attributes.Any(att => att.PropertyName == property.PropertyName)).ToList();
+            }
+
+            foreach (var property in properties)
+            {
+                property.PropertyName = _nameConverter.ToJsonPropertyName(property.PropertyName);
+            }
+
+            return properties;
+        }
+
+        protected override JsonContract CreateContract(Type objectType)
+        {
+            var contract = base.CreateContract(objectType);
+
+            contract.OnSerializingCallbacks.Add((obj, context) => { _depth++; });
+            contract.OnSerializedCallbacks.Add((obj, context) => { _depth--; });
+
+            return contract;
+        }
+    }
+}

--- a/Tests/Helpers/DateISOConverter.cs
+++ b/Tests/Helpers/DateISOConverter.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Tests.Helpers
+{
+    internal class DateISOConverter : JsonConverter<DateTime>
+    {
+        public string DateTimeFormat = @"yyyy-MM-dd";
+
+        public DateISOConverter() { }
+
+        public DateISOConverter(string datetimeFormat)
+        {
+            DateTimeFormat = datetimeFormat;
+        }
+
+        public override void WriteJson(JsonWriter writer, DateTime value, JsonSerializer serializer)
+        {
+            var timespanFormatted = $"{value.ToString(DateTimeFormat)}";
+            writer.WriteValue(timespanFormatted);
+        }
+
+        public override DateTime ReadJson(JsonReader reader, Type objectType, DateTime existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            return DateTime.ParseExact((string)reader.Value, DateTimeFormat, null);
+        }
+    }
+}

--- a/Tests/Models/PersonWithJsonConverters.cs
+++ b/Tests/Models/PersonWithJsonConverters.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tests.Helpers;
+
+namespace Tests.Models
+{
+    public class PersonWithJsonConverters
+    {
+        public PersonWithJsonConverters()
+        {
+        }
+
+        public string Id { get; set; } = "1";
+
+        public string Name { get; set; } = "Dustin";
+
+        [JsonConverter(typeof(DateISOConverter))]
+        public DateTime Birthday { get; set; } = new DateTime(1992, 9, 28);
+
+        public DateTime WorkAniversary { get; set; } = new DateTime(2019, 4, 27);
+    }
+
+
+}

--- a/Tests/Models/PersonWithJsonConvertersResource.cs
+++ b/Tests/Models/PersonWithJsonConvertersResource.cs
@@ -1,0 +1,21 @@
+﻿using Saule;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests.Models
+{
+    public class PersonWithJsonConvertersResource : ApiResource
+    {
+        public PersonWithJsonConvertersResource()
+        {
+            OfType("Person");
+            WithId(nameof(PersonWithJsonConverters.Id));
+            Attribute(nameof(PersonWithJsonConverters.Name));
+            Attribute(nameof(PersonWithJsonConverters.Birthday));
+            Attribute(nameof(PersonWithJsonConverters.WorkAniversary));
+        }
+    }
+}

--- a/Tests/Serialization/ResourceSerializerTests.cs
+++ b/Tests/Serialization/ResourceSerializerTests.cs
@@ -708,6 +708,23 @@ namespace Tests.Serialization
             });
         }
 
+        [Fact(DisplayName = "Use Json Converters when seirializing")]
+        public void SerializeUsingJsonConverter()
+        {
+            var person = new PersonWithJsonConverters();
+
+            var target = new ResourceSerializer(person, new PersonWithJsonConvertersResource(),
+                GetUri(id: "1"), DefaultPathBuilder, null, null, null);
+
+            var result = target.Serialize();
+            _output.WriteLine(result.ToString());
+
+            // Using a Json converter
+            Assert.Equal(result["data"]["attributes"]["birthday"], "1992-09-28");
+            // Not using a converter
+            Assert.Equal(result["data"]["attributes"]["work-aniversary"], "2019-04-27T00:00:00");
+        }
+
         internal static IEnumerable<KeyValuePair<string, string>> GetQuery(string key, string value)
         {
             yield return new KeyValuePair<string, string>(key, value);

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Controllers\BrokenController.cs" />
     <Compile Include="Controllers\CompaniesController.cs" />
     <Compile Include="Controllers\StaticController.cs" />
+    <Compile Include="Helpers\DateISOConverter.cs" />
     <Compile Include="Helpers\Get.cs" />
     <Compile Include="Helpers\HttpClientExtensions.cs" />
     <Compile Include="Helpers\NewSetupJsonApiServer.cs" />
@@ -149,6 +150,8 @@
     <Compile Include="Models\PersonWithDefaultIdResource.cs" />
     <Compile Include="Models\PersonWithDifferentId.cs" />
     <Compile Include="Models\PersonWithDifferentIdResource.cs" />
+    <Compile Include="Models\PersonWithJsonConverters.cs" />
+    <Compile Include="Models\PersonWithJsonConvertersResource.cs" />
     <Compile Include="Models\PersonWithNoId.cs" />
     <Compile Include="Models\PersonWithNoJob.cs" />
     <Compile Include="Controllers\PeopleController.cs" />


### PR DESCRIPTION
Added the ability for JsonConverters attached to the sourceobject properties to be triggered. Had to add filtering and depth counter to the ContractResolver so we don't serialize the whole object.

After some discussion about how this could be added. We didn't want to try and add logic that was creating instances of the converters that we might have to support given the number of different converters available. This simply invokes the Converters through the standard Json.Net serialization process.

This is missing tests, I will add them if you think this is a good solution, but it passes all existing ones. This aims to solve issue #237 

Looking for input or alternative ways to achieve the same result.