### PR TITLE
Added IApiResourceProvider and IApiResourceProviderFactory so ApiReso…

### DIFF
--- a/Saule/Http/JsonApiConfiguration.cs
+++ b/Saule/Http/JsonApiConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using Saule.Resources;
 using Saule.Serialization;
 
 namespace Saule.Http
@@ -36,5 +37,10 @@ namespace Saule.Http
         /// Gets the expressions that are used to evaluate filter queries on a per-type basis.
         /// </summary>
         public QueryFilterExpressionCollection QueryFilterExpressions { get; } = new QueryFilterExpressionCollection();
+
+        /// <summary>
+        /// Gets or sets the factory that creates request specific ApiResourceProvider
+        /// </summary>
+        public IApiResourceProviderFactory ApiResourceProviderFactory { get; set; } = new DefaultApiResourceProviderFactory();
     }
 }

--- a/Saule/Http/PreprocessingDelegatingHandler.cs
+++ b/Saule/Http/PreprocessingDelegatingHandler.cs
@@ -9,6 +9,7 @@ using System.Web.Http;
 using System.Web.Http.Controllers;
 using Saule.Queries;
 using Saule.Queries.Pagination;
+using Saule.Resources;
 using Saule.Serialization;
 
 namespace Saule.Http
@@ -43,11 +44,15 @@ namespace Saule.Http
 
             ApiResource resource = null;
             bool isHttpError = content is HttpError || content is IEnumerable<HttpError>;
-            if (request.Properties.ContainsKey(Constants.PropertyNames.ResourceDescriptor))
+            IApiResourceProvider resourceProvider = null;
+
+            if (!isHttpError)
             {
-                resource = (ApiResource)request.Properties[Constants.PropertyNames.ResourceDescriptor];
+                resourceProvider = config.ApiResourceProviderFactory.Create(request);
+                resource = resourceProvider?.Resolve(content);
             }
-            else if (content != null && !isHttpError)
+
+            if (resource == null && content != null && !isHttpError)
             {
                 content = new JsonApiException(
                     ErrorType.Server,
@@ -64,7 +69,7 @@ namespace Saule.Http
 
             PrepareUrlPathBuilder(jsonApi, request, config);
 
-            return jsonApi.PreprocessContent(content, resource, request.RequestUri, config);
+            return jsonApi.PreprocessContent(content, request.RequestUri, config, resourceProvider);
         }
 
         /// <inheritdoc/>

--- a/Saule/Http/PreprocessingDelegatingHandler.cs
+++ b/Saule/Http/PreprocessingDelegatingHandler.cs
@@ -49,7 +49,20 @@ namespace Saule.Http
             if (!isHttpError)
             {
                 resourceProvider = config.ApiResourceProviderFactory.Create(request);
-                resource = resourceProvider?.Resolve(content);
+                if (resourceProvider == null)
+                {
+                    content = new JsonApiException(
+                        ErrorType.Server,
+                        "ApiResourceProviderFactory returned null but it should always return an instance of IApiResourceProvider.")
+                    {
+                        HelpLink = "https://github.com/joukevandermaas/saule/wiki"
+                    };
+                    isHttpError = true;
+                }
+                else
+                {
+                    resource = resourceProvider.Resolve(content);
+                }
             }
 
             if (resource == null && content != null && !isHttpError)

--- a/Saule/Http/ReturnsResourceAttribute.cs
+++ b/Saule/Http/ReturnsResourceAttribute.cs
@@ -53,8 +53,13 @@ namespace Saule.Http
                 actionContext.Response = new HttpResponseMessage(HttpStatusCode.UnsupportedMediaType);
             }
 
-            actionContext.Request.Properties.Add(Constants.PropertyNames.ResourceDescriptor, Resource);
+            AddResourceToRequest(actionContext.Request, Resource);
             base.OnActionExecuting(actionContext);
+        }
+
+        internal static void AddResourceToRequest(HttpRequestMessage request, ApiResource resource)
+        {
+            request.Properties.Add(Constants.PropertyNames.ResourceDescriptor, resource);
         }
     }
 }

--- a/Saule/JsonApiSerializer.cs
+++ b/Saule/JsonApiSerializer.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using Saule.Http;
 using Saule.Queries;
 using Saule.Queries.Pagination;
+using Saule.Resources;
 using Saule.Serialization;
 
 namespace Saule
@@ -32,7 +33,7 @@ namespace Saule
             return result.ResourceSerializer.Serialize(jsonSerializer);
         }
 
-        public PreprocessResult PreprocessContent(object @object, ApiResource resource, Uri requestUri, JsonApiConfiguration config)
+        public PreprocessResult PreprocessContent(object @object, Uri requestUri, JsonApiConfiguration config, IApiResourceProvider apiResourceProvider)
         {
             var result = new PreprocessResult
             {
@@ -61,6 +62,7 @@ namespace Saule
 
                 if (QueryContext != null && !QueryContext.IsHandledQuery)
                 {
+                    var resource = apiResourceProvider.Resolve(dataObject);
                     if (QueryContext.Filter != null)
                     {
                         dataObject = Query.ApplyFiltering(dataObject, QueryContext.Filter, resource);
@@ -79,7 +81,7 @@ namespace Saule
 
                 result.ResourceSerializer = new ResourceSerializer(
                         value: dataObject,
-                        type: resource,
+                        apiResourceProvider: apiResourceProvider,
                         baseUrl: requestUri,
                         propertyNameConverter: config.PropertyNameConverter,
                         urlBuilder: UrlPathBuilder,

--- a/Saule/JsonApiSerializerOfT.cs
+++ b/Saule/JsonApiSerializerOfT.cs
@@ -12,6 +12,7 @@ using Saule.Queries.Filtering;
 using Saule.Queries.Including;
 using Saule.Queries.Pagination;
 using Saule.Queries.Sorting;
+using Saule.Resources;
 using Saule.Serialization;
 
 namespace Saule
@@ -93,8 +94,9 @@ namespace Saule
             var queryContext = GetQueryContext(request.GetQueryNameValuePairs());
 
             _serializer.QueryContext = queryContext;
+            var apiResourceProvider = new DefaultApiResourceProvider(new T());
 
-            var preprocessResult = _serializer.PreprocessContent(@object, new T(), requestUri, config);
+            var preprocessResult = _serializer.PreprocessContent(@object, requestUri, config, apiResourceProvider);
             return JsonApiSerializer.Serialize(preprocessResult);
         }
 

--- a/Saule/JsonApiSerializerOfT.cs
+++ b/Saule/JsonApiSerializerOfT.cs
@@ -91,10 +91,11 @@ namespace Saule
             }
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            ReturnsResourceAttribute.AddResourceToRequest(request, new T());
             var queryContext = GetQueryContext(request.GetQueryNameValuePairs());
 
             _serializer.QueryContext = queryContext;
-            var apiResourceProvider = new DefaultApiResourceProvider(new T());
+            var apiResourceProvider = config.ApiResourceProviderFactory.Create(request);
 
             var preprocessResult = _serializer.PreprocessContent(@object, requestUri, config, apiResourceProvider);
             return JsonApiSerializer.Serialize(preprocessResult);

--- a/Saule/Resources/DefaultApiResourceProvider.cs
+++ b/Saule/Resources/DefaultApiResourceProvider.cs
@@ -1,0 +1,28 @@
+﻿namespace Saule.Resources
+{
+    /// <summary>
+    /// Default ApiResourceProvider that always return the same ApiResource that is bound to current request regardless of the object type
+    /// </summary>
+    public class DefaultApiResourceProvider : IApiResourceProvider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultApiResourceProvider"/> class.
+        /// </summary>
+        /// <param name="apiResource">default ApiResource based on the controller's attribute</param>
+        public DefaultApiResourceProvider(ApiResource apiResource)
+        {
+            ApiResource = apiResource;
+        }
+
+        /// <summary>
+        /// Gets current api resource
+        /// </summary>
+        protected ApiResource ApiResource { get; }
+
+        /// <inheritdoc/>
+        public virtual ApiResource Resolve(object dataObject)
+        {
+            return ApiResource;
+        }
+    }
+}

--- a/Saule/Resources/DefaultApiResourceProviderFactory.cs
+++ b/Saule/Resources/DefaultApiResourceProviderFactory.cs
@@ -10,7 +10,8 @@ namespace Saule.Resources
         /// <inheritdoc/>
         public IApiResourceProvider Create(HttpRequestMessage request)
         {
-            if (request.Properties.TryGetValue(Constants.PropertyNames.ResourceDescriptor, out object resource) && resource is ApiResource apiResource)
+            object resource;
+            if (request.Properties.TryGetValue(Constants.PropertyNames.ResourceDescriptor, out resource) && resource is ApiResource apiResource)
             {
                 return new DefaultApiResourceProvider(apiResource);
             }

--- a/Saule/Resources/DefaultApiResourceProviderFactory.cs
+++ b/Saule/Resources/DefaultApiResourceProviderFactory.cs
@@ -11,8 +11,9 @@ namespace Saule.Resources
         public IApiResourceProvider Create(HttpRequestMessage request)
         {
             object resource;
-            if (request.Properties.TryGetValue(Constants.PropertyNames.ResourceDescriptor, out resource) && resource is ApiResource apiResource)
+            if (request.Properties.TryGetValue(Constants.PropertyNames.ResourceDescriptor, out resource) && resource is ApiResource)
             {
+                var apiResource = (ApiResource)resource;
                 return new DefaultApiResourceProvider(apiResource);
             }
 

--- a/Saule/Resources/DefaultApiResourceProviderFactory.cs
+++ b/Saule/Resources/DefaultApiResourceProviderFactory.cs
@@ -1,0 +1,22 @@
+﻿using System.Net.Http;
+
+namespace Saule.Resources
+{
+    /// <summary>
+    /// Default provider factory that resolves attributes based on attributes and HttpRequestMessage
+    /// </summary>
+    public class DefaultApiResourceProviderFactory : IApiResourceProviderFactory
+    {
+        /// <inheritdoc/>
+        public IApiResourceProvider Create(HttpRequestMessage request)
+        {
+            if (request.Properties.TryGetValue(Constants.PropertyNames.ResourceDescriptor, out object resource) && resource is ApiResource apiResource)
+            {
+                return new DefaultApiResourceProvider(apiResource);
+            }
+
+            // if no resource was specified then we return empty provider that will always return null
+            return new DefaultApiResourceProvider(null);
+        }
+    }
+}

--- a/Saule/Resources/IApiResourceProvider.cs
+++ b/Saule/Resources/IApiResourceProvider.cs
@@ -1,0 +1,15 @@
+﻿namespace Saule.Resources
+{
+    /// <summary>
+    /// ApiResourceProvider that can resolve specific ApiResource based on the data object
+    /// </summary>
+    public interface IApiResourceProvider
+    {
+        /// <summary>
+        /// Returns ApiResource based on the data object
+        /// </summary>
+        /// <param name="dataObject">Data object that is serialized. If it's an array, then it will be called for each item in the array</param>
+        /// <returns>ApiResource that should be used for specific data object</returns>
+        ApiResource Resolve(object dataObject);
+    }
+}

--- a/Saule/Resources/IApiResourceProviderFactory.cs
+++ b/Saule/Resources/IApiResourceProviderFactory.cs
@@ -1,0 +1,17 @@
+﻿using System.Net.Http;
+
+namespace Saule.Resources
+{
+    /// <summary>
+    /// Factory that creates IApiResourceProvider. It can be overriden at JsonApiConfiguration
+    /// </summary>
+    public interface IApiResourceProviderFactory
+    {
+        /// <summary>
+        /// Creates ApiResourceProvider based on the current http request
+        /// </summary>
+        /// <param name="request">HttpRequest that is processsed at the moment</param>
+        /// <returns>ApiResourceProvider instance bound to current request</returns>
+        IApiResourceProvider Create(HttpRequestMessage request);
+    }
+}

--- a/Saule/Resources/IApiResourceProviderFactory.cs
+++ b/Saule/Resources/IApiResourceProviderFactory.cs
@@ -8,7 +8,7 @@ namespace Saule.Resources
     public interface IApiResourceProviderFactory
     {
         /// <summary>
-        /// Creates ApiResourceProvider based on the current http request
+        /// Creates ApiResourceProvider based on the current http request. It should always return a provider. Provider itself might return null ApiResource but if provider itself is null, then the error would be thrown
         /// </summary>
         /// <param name="request">HttpRequest that is processsed at the moment</param>
         /// <returns>ApiResourceProvider instance bound to current request</returns>

--- a/Saule/Saule.csproj
+++ b/Saule/Saule.csproj
@@ -72,6 +72,10 @@
     <Compile Include="Queries\Fieldset\FieldsetProperty.cs" />
     <Compile Include="Queries\Pagination\PagedResult.cs" />
     <Compile Include="Queries\Pagination\PagedResultQuery.cs" />
+    <Compile Include="Resources\DefaultApiResourceProvider.cs" />
+    <Compile Include="Resources\DefaultApiResourceProviderFactory.cs" />
+    <Compile Include="Resources\IApiResourceProvider.cs" />
+    <Compile Include="Resources\IApiResourceProviderFactory.cs" />
     <Compile Include="Serialization\CamelCasePropertyNameConverter.cs" />
     <Compile Include="Serialization\DefaultPropertyNameConverter.cs" />
     <Compile Include="Serialization\IPropertyNameConverter.cs" />

--- a/Saule/Serialization/ResourceGraph.cs
+++ b/Saule/Serialization/ResourceGraph.cs
@@ -10,25 +10,28 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 using Saule.Queries.Including;
+using Saule.Resources;
 
 namespace Saule.Serialization
 {
     internal class ResourceGraph
     {
         private readonly IDictionary<ResourceGraphNodeKey, ResourceGraphNode> _nodes;
+        private readonly IApiResourceProvider _apiResourceProvider;
 
         public ResourceGraph(
             object obj,
-            ApiResource resource,
+            IApiResourceProvider apiResourceProvider,
             ResourceGraphPathSet includePaths)
         {
             obj.ThrowIfNull(nameof(obj));
-            resource.ThrowIfNull(nameof(resource));
+            apiResourceProvider.ThrowIfNull(nameof(apiResourceProvider));
             includePaths.ThrowIfNull(nameof(includePaths));
 
             _nodes = new Dictionary<ResourceGraphNodeKey, ResourceGraphNode>();
+            _apiResourceProvider = apiResourceProvider;
 
-            Build(obj, resource, includePaths, 0);
+            Build(obj, null, includePaths, 0);
         }
 
         public IEnumerable<ResourceGraphNode> DataNodes
@@ -64,10 +67,15 @@ namespace Saule.Serialization
             {
                 foreach (var o in (IEnumerable)obj)
                 {
-                    Build(o, resource, includePaths, depth);
+                    Build(o, null, includePaths, depth);
                 }
 
                 return;
+            }
+
+            if (resource == null)
+            {
+                resource = _apiResourceProvider.Resolve(obj);
             }
 
             // keys (type & id pair) uniquely identifier each resource in a compount document

--- a/Tests/Controllers/ShapeController.cs
+++ b/Tests/Controllers/ShapeController.cs
@@ -12,12 +12,16 @@ namespace Tests.Controllers
     {
         [HttpGet]
         [Route("shapes")]
+        [AllowsQuery]
         public IEnumerable<Shape> GetAllShapes()
         {
             return new Shape[]
             {
                 new Circle(true, "1"),
-                new Rectangle(true, "2"),
+                new Rectangle(true, "2")
+                {
+                    Color = "Green"
+                },
                 new Circle(true, "3"),
             };
         }

--- a/Tests/Controllers/ShapeController.cs
+++ b/Tests/Controllers/ShapeController.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+using Saule.Http;
+using Tests.Models.Inheritance;
+
+namespace Tests.Controllers
+{
+    [ReturnsResource(typeof(ShapeResource))]
+    [RoutePrefix("api")]
+    public class ShapeController : ApiController
+    {
+        [HttpGet]
+        [Route("shapes")]
+        public IEnumerable<Shape> GetAllShapes()
+        {
+            return new Shape[]
+            {
+                new Circle(true, "1"),
+                new Rectangle(true, "2"),
+                new Circle(true, "3"),
+            };
+        }
+        
+        [HttpGet]
+        [Route("shape/{id}")]
+        public Shape GetShape(string id)
+        {
+            return GetAllShapes().FirstOrDefault(s => s.Id == id);
+        }
+    }
+}

--- a/Tests/Integration/JsonApiFormatterInheritenceTests.cs
+++ b/Tests/Integration/JsonApiFormatterInheritenceTests.cs
@@ -1,0 +1,134 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using Saule;
+using Saule.Http;
+using Saule.Resources;
+using Saule.Serialization;
+using Tests.Helpers;
+using Tests.Models.Inheritance;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests.Integration
+{
+    public class JsonApiFormatterInheritenceTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public JsonApiFormatterInheritenceTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact(DisplayName = "Default endpoint that returns all items")]
+        public async Task GetAllItems()
+        {
+            using (var server = CreateServer())
+            {
+                var client = server.GetClient();
+                var result = await client.GetJsonResponseAsync("api/shapes");
+                _output.WriteLine(result.ToString());
+
+                var items = result["data"] as JArray;
+                Assert.Equal(3, items.Count);
+
+                var circle1 = items[0];
+                var rectangle2 = items[1];
+                var circle3 = items[2];
+                
+                ValidateCircle(circle1,"1");
+                ValidateRectangle(rectangle2, "2");
+                ValidateCircle(circle3,"3");
+            }
+        }
+
+        [Fact(DisplayName = "Get a specific circle and validate the attributes")]
+        public async Task GetSpecificCircle()
+        {
+            using (var server = CreateServer())
+            {
+                var client = server.GetClient();
+                // id 1 is mapped to circle object
+                var result = await client.GetJsonResponseAsync("api/shape/1");
+                _output.WriteLine(result.ToString());
+
+                var circle = result["data"];
+
+                ValidateCircle(circle, "1");
+            }
+        }
+        
+        [Fact(DisplayName = "Get a specific rectangle and validate the attributes")]
+        public async Task GetSpecificRectangle()
+        {
+            using (var server = CreateServer())
+            {
+                var client = server.GetClient();
+                // id 2 is mapped to rectangle object
+                var result = await client.GetJsonResponseAsync("api/shape/2");
+                _output.WriteLine(result.ToString());
+
+                var rectangle = result["data"];
+
+                ValidateRectangle(rectangle, "2");
+            }
+        }
+
+        
+        private static void ValidateRectangle(JToken rectangle2, string expectedId)
+        {
+            Assert.Equal("rectangle", rectangle2["type"]);
+            Assert.Equal(expectedId, rectangle2["id"]);
+            Assert.Equal("Purple", rectangle2["attributes"]["color"]);
+            Assert.Equal(10, rectangle2["attributes"]["left"].Value<int>());
+            Assert.Equal(10, rectangle2["attributes"]["top"].Value<int>());
+            Assert.Equal(100, rectangle2["attributes"]["width"].Value<int>());
+            Assert.Equal(100, rectangle2["attributes"]["height"].Value<int>());
+            Assert.Equal(5, rectangle2["attributes"].Count());
+        }
+
+        private static void ValidateCircle(JToken circle1, string expectedId)
+        {
+            Assert.Equal("circle", circle1["type"]);
+            Assert.Equal(expectedId, circle1["id"]);
+            Assert.Equal("Purple", circle1["attributes"]["color"]);
+            Assert.Equal(42, circle1["attributes"]["radius"].Value<decimal>());
+            Assert.Equal(2, circle1["attributes"].Count());
+        }
+
+        private NewSetupJsonApiServer CreateServer()
+        {
+            var config = new JsonApiConfiguration()
+            {
+                ApiResourceProviderFactory = new ShapeApiResourceProviderFactory()
+            };
+            return new NewSetupJsonApiServer(config);
+        }
+
+        public class ShapeApiResourceProviderFactory : IApiResourceProviderFactory
+        {
+            public IApiResourceProvider Create(HttpRequestMessage request)
+            {
+                return new ShapeApiResourceProvider();
+            }
+        }
+
+        public class ShapeApiResourceProvider : IApiResourceProvider
+        {
+            public ApiResource Resolve(object dataObject)
+            {
+                switch (dataObject)
+                {
+                    case Circle _: return new CircleResource();
+                    case Rectangle _: return new RectangleResource();
+                    default: return new ShapeResource();
+                }
+            }
+        }
+    }
+}

--- a/Tests/Integration/JsonApiFormatterInheritenceTests.cs
+++ b/Tests/Integration/JsonApiFormatterInheritenceTests.cs
@@ -122,12 +122,17 @@ namespace Tests.Integration
         {
             public ApiResource Resolve(object dataObject)
             {
-                switch (dataObject)
+                if (dataObject is Circle)
                 {
-                    case Circle _: return new CircleResource();
-                    case Rectangle _: return new RectangleResource();
-                    default: return new ShapeResource();
+                    return new CircleResource();
                 }
+
+                if (dataObject is Rectangle)
+                {
+                    return new RectangleResource();
+                }
+
+                return new ShapeResource();
             }
         }
     }

--- a/Tests/Models/Inheritance/Circle.cs
+++ b/Tests/Models/Inheritance/Circle.cs
@@ -1,0 +1,16 @@
+﻿namespace Tests.Models.Inheritance
+{
+    public class Circle : Shape
+    {
+        public Circle(bool prefill = false, string id = "123")
+            : base(prefill, id)
+        {
+            if (!prefill) return;
+
+            Radius = 42;
+        }
+
+        
+        public decimal Radius { get; set; }
+    }
+}

--- a/Tests/Models/Inheritance/CircleResource.cs
+++ b/Tests/Models/Inheritance/CircleResource.cs
@@ -1,0 +1,10 @@
+﻿namespace Tests.Models.Inheritance
+{
+    public class CircleResource : ShapeResource
+    {
+        public CircleResource()
+        {
+            Attribute(nameof(Circle.Radius));
+        }
+    }
+}

--- a/Tests/Models/Inheritance/Rectangle.cs
+++ b/Tests/Models/Inheritance/Rectangle.cs
@@ -1,0 +1,22 @@
+﻿namespace Tests.Models.Inheritance
+{
+    public class Rectangle : Shape
+    {
+        public Rectangle(bool prefill = false, string id = "123")
+            : base(prefill, id)
+        {
+            if (!prefill) return;
+
+            Left = 10;
+            Top = 10;
+            Width = 100;
+            Height = 100;
+        }
+
+        
+        public int Left { get; set; }
+        public int Top { get; set; }
+        public int Width { get; set; }
+        public int Height { get; set; }
+    }
+}

--- a/Tests/Models/Inheritance/RectangleResource.cs
+++ b/Tests/Models/Inheritance/RectangleResource.cs
@@ -1,0 +1,13 @@
+﻿namespace Tests.Models.Inheritance
+{
+    public class RectangleResource : ShapeResource
+    {
+        public RectangleResource()
+        {
+            Attribute(nameof(Rectangle.Left));
+            Attribute(nameof(Rectangle.Top));
+            Attribute(nameof(Rectangle.Width));
+            Attribute(nameof(Rectangle.Height));
+        }
+    }
+}

--- a/Tests/Models/Inheritance/Shape.cs
+++ b/Tests/Models/Inheritance/Shape.cs
@@ -1,0 +1,16 @@
+﻿namespace Tests.Models.Inheritance
+{
+    public abstract class Shape
+    {
+        protected Shape(bool prefill = false, string id = "123")
+        {
+            Id = id;
+            if (!prefill) return;
+
+            Color = "Purple";
+        }
+
+        public string Id { get; set; }
+        public string Color { get; set; }
+    }
+}

--- a/Tests/Models/Inheritance/ShapeResource.cs
+++ b/Tests/Models/Inheritance/ShapeResource.cs
@@ -1,0 +1,14 @@
+﻿using Saule;
+
+namespace Tests.Models.Inheritance
+{
+    public class ShapeResource : ApiResource
+    {
+        public ShapeResource()
+        {
+            WithId(nameof(Shape.Id));
+
+            Attribute(nameof(Shape.Color));
+        }
+    }
+}

--- a/Tests/Serialization/MetadataTests.cs
+++ b/Tests/Serialization/MetadataTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Saule;
+using Saule.Resources;
 using Saule.Serialization;
 using Tests.Helpers;
 using Tests.Models;
@@ -32,7 +33,7 @@ namespace Tests.Serialization
 
             var target = new ResourceSerializer(
                 company,
-                mock.Object,
+                new DefaultApiResourceProvider(mock.Object),
                 new Uri("http://localhost/people/123"),
                 new DefaultUrlPathBuilder(),
                 null,
@@ -63,7 +64,7 @@ namespace Tests.Serialization
 
             var target = new ResourceSerializer(
                 company,
-                mock.Object,
+                new DefaultApiResourceProvider(mock.Object),
                 new Uri("http://localhost/people/123"),
                 new DefaultUrlPathBuilder(),
                 null,
@@ -91,7 +92,7 @@ namespace Tests.Serialization
 
             var target = new ResourceSerializer(
                 company,
-                mock.Object,
+                new DefaultApiResourceProvider(mock.Object),
                 new Uri("http://localhost/people/123"),
                 new DefaultUrlPathBuilder(),
                 null,
@@ -117,7 +118,7 @@ namespace Tests.Serialization
 
             var target = new ResourceSerializer(
                 company,
-                mock.Object,
+                new DefaultApiResourceProvider(mock.Object),
                 new Uri("http://localhost/people/123"),
                 new DefaultUrlPathBuilder(),
                 null,
@@ -142,7 +143,7 @@ namespace Tests.Serialization
 
             var target = new ResourceSerializer(
                 company,
-                mock.Object,
+                new DefaultApiResourceProvider(mock.Object),
                 new Uri("http://localhost/people/123"),
                 new DefaultUrlPathBuilder(),
                 null,
@@ -156,7 +157,7 @@ namespace Tests.Serialization
 
             target = new ResourceSerializer(
                 companies,
-                mock.Object,
+                new DefaultApiResourceProvider(mock.Object),
                 new Uri("http://localhost/people/123"),
                 new DefaultUrlPathBuilder(),
                 null,
@@ -174,7 +175,7 @@ namespace Tests.Serialization
 
             var target = new ResourceSerializer(
                 company,
-                new CompanyResource(),
+                new DefaultApiResourceProvider(new CompanyResource()),
                 new Uri("http://localhost/people/123"),
                 new DefaultUrlPathBuilder(),
                 null,

--- a/Tests/Serialization/ResourceDeserializerTests.cs
+++ b/Tests/Serialization/ResourceDeserializerTests.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using Saule.Serialization;
 using System.Linq;
 using Saule;
+using Saule.Resources;
 using Tests.Helpers;
 using Tests.Models;
 using Xunit;
@@ -23,11 +24,12 @@ namespace Tests.Serialization
             _person.Friends = Get.People(1);
             _person.FamilyMembers = Get.People(2);
             _people = Get.People(5).ToArray();
+            var personResourceProvider = new DefaultApiResourceProvider(new PersonResource());
             var singleSerializer = new ResourceSerializer(
-            _person, new PersonResource(), new Uri("http://example.com/people/1"),
+            _person, personResourceProvider, new Uri("http://example.com/people/1"),
             new DefaultUrlPathBuilder(), null, null, null);
             var multiSerializer = new ResourceSerializer(
-                _people, new PersonResource(), new Uri("http://example.com/people/"),
+                _people, personResourceProvider, new Uri("http://example.com/people/"),
                 new DefaultUrlPathBuilder(), null, null, null);
 
             _singleJson = JToken.Parse(singleSerializer.Serialize().ToString());
@@ -52,7 +54,7 @@ namespace Tests.Serialization
             var camelCasePropertyNameConverter = new CamelCasePropertyNameConverter();
 
             var singleSerializer = new ResourceSerializer(
-                _person, new PersonResource(), new Uri("http://example.com/people/1"),
+                _person, new DefaultApiResourceProvider(new PersonResource()), new Uri("http://example.com/people/1"),
                 new DefaultUrlPathBuilder(), null, null, null, camelCasePropertyNameConverter);
 
             var singleJson = JToken.Parse(singleSerializer.Serialize().ToString());

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -111,6 +111,7 @@
     <Compile Include="ApiResourceTests.cs" />
     <Compile Include="Controllers\BrokenController.cs" />
     <Compile Include="Controllers\CompaniesController.cs" />
+    <Compile Include="Controllers\ShapeController.cs" />
     <Compile Include="Controllers\StaticController.cs" />
     <Compile Include="Helpers\DateISOConverter.cs" />
     <Compile Include="Helpers\Get.cs" />
@@ -120,6 +121,7 @@
     <Compile Include="Helpers\ExpressionComparer.cs" />
     <Compile Include="Http\JsonApiMediaTypeFormatterTests.cs" />
     <Compile Include="Http\QueryFilterExpressionCollectionTests.cs" />
+    <Compile Include="Integration\JsonApiFormatterInheritenceTests.cs" />
     <Compile Include="Integration\PropertyNameConverterTests.cs" />
     <Compile Include="Integration\JsonApiMediaTypeFormatterTests.cs" />
     <Compile Include="Models\Car.cs" />
@@ -137,6 +139,12 @@
     <Compile Include="Models\GuidAsId.cs" />
     <Compile Include="Helpers\ObsoleteSetupJsonApiServer.cs" />
     <Compile Include="Helpers\Paths.cs" />
+    <Compile Include="Models\Inheritance\Circle.cs" />
+    <Compile Include="Models\Inheritance\CircleResource.cs" />
+    <Compile Include="Models\Inheritance\Rectangle.cs" />
+    <Compile Include="Models\Inheritance\RectangleResource.cs" />
+    <Compile Include="Models\Inheritance\Shape.cs" />
+    <Compile Include="Models\Inheritance\ShapeResource.cs" />
     <Compile Include="Models\LazyPerson.cs" />
     <Compile Include="Models\PersonFilter.cs" />
     <Compile Include="Models\PersonJobOnlyRelatedLinksResource.cs" />


### PR DESCRIPTION
Hi Jouke,

here is the change that i mentioned in #241 . basically i made

```
    public interface IApiResourceProviderFactory
    {
        IApiResourceProvider Create(HttpRequestMessage request);
    }

    public interface IApiResourceProvider
    {
        ApiResource Resolve(object dataObject);
    }
```

The first one called in `Saule/Http/PreprocessingDelegatingHandler.cs` and it creates a specific provider based on the current http request. And then it uses created `IApiResourceProvider` and passes it to `Saule/Serialization/ResourceGraph.cs` and `Saule/Serialization/ResourceSerializer.cs`. And they are calling it with current data object and it returns `ApiResource`. 

In the default implementation it uses the same `request.Properties.TryGetValue(Constants.PropertyNames.ResourceDescriptor, out object resource)` and then it always returns it. But potentially if consumer wants, it can have custom implementation that won't depend on `ReturnsResourceAttribute` and can make `ApiResource` based on own rules.

In our case we are creating specific resource based on the specific type.

I added 3 new unit tests `Tests/Integration/JsonApiFormatterInheritenceTests.cs` that validates it. And also as i changed `ApiResource` parameter to `IApiResourceProvider` in `ResourceSerializer` - i updated a bunch of unit tests to wrap existing `ApiResource` provider


I'll check it tomorrow to be sure that i didn't miss something but it should be ready for the review