### PR TITLE
Updated IApiResourceProvider to care about relationship\include cases

### DIFF
--- a/Saule/Resources/DefaultApiResourceProvider.cs
+++ b/Saule/Resources/DefaultApiResourceProvider.cs
@@ -24,5 +24,11 @@
         {
             return ApiResource;
         }
+
+        /// <inheritdoc/>
+        public virtual ApiResource ResolveRelationship(object dataObject, ApiResource relationship)
+        {
+            return relationship;
+        }
     }
 }

--- a/Saule/Resources/IApiResourceProvider.cs
+++ b/Saule/Resources/IApiResourceProvider.cs
@@ -11,5 +11,13 @@
         /// <param name="dataObject">Data object that is serialized. If it's an array, then it will be called for each item in the array</param>
         /// <returns>ApiResource that should be used for specific data object</returns>
         ApiResource Resolve(object dataObject);
+
+        /// <summary>
+        /// Returns ApiResource based on the data object and specific relationship
+        /// </summary>
+        /// <param name="dataObject">Data object that is serialized. If it's an array, then it will be called for each item in the array</param>
+        /// <param name="relationship">Relationship resource for which we are resolving api resource</param>
+        /// <returns>ApiResource that should be used for specific data object and relationship</returns>
+        ApiResource ResolveRelationship(object dataObject, ApiResource relationship);
     }
 }

--- a/Saule/Serialization/ResourceGraph.cs
+++ b/Saule/Serialization/ResourceGraph.cs
@@ -52,7 +52,7 @@ namespace Saule.Serialization
 
         private void Build(
             object obj,
-            ApiResource resource,
+            ApiResource relatedResource,
             ResourceGraphPathSet includePaths,
             int depth,
             string propertyName = null)
@@ -73,9 +73,17 @@ namespace Saule.Serialization
                 return;
             }
 
-            if (resource == null)
+            ApiResource resource;
+
+            // if we are serializing top object, then we just resolve it based on api resource of the endpoint
+            // but if are processing relationship's includes, then we need to resolve it based on the relationship itself
+            if (relatedResource == null)
             {
                 resource = _apiResourceProvider.Resolve(obj);
+            }
+            else
+            {
+                resource = _apiResourceProvider.ResolveRelationship(obj, relatedResource);
             }
 
             // keys (type & id pair) uniquely identifier each resource in a compount document

--- a/Saule/Serialization/ResourceSerializer.cs
+++ b/Saule/Serialization/ResourceSerializer.cs
@@ -424,7 +424,8 @@ namespace Saule.Serialization
 
                 foreach (var sourceObject in (IEnumerable)relationship.SourceObject ?? new JArray())
                 {
-                    content.Add(JObject.FromObject(new ResourceGraphNodeKey(sourceObject, relationship.Relationship.RelatedResource)));
+                    var resource = _apiResourceProvider.ResolveRelationship(sourceObject, relationship.Relationship.RelatedResource);
+                    content.Add(JObject.FromObject(new ResourceGraphNodeKey(sourceObject, resource)));
                 }
 
                 return content;

--- a/Tests/Controllers/ShapeController.cs
+++ b/Tests/Controllers/ShapeController.cs
@@ -6,13 +6,13 @@ using Tests.Models.Inheritance;
 
 namespace Tests.Controllers
 {
-    [ReturnsResource(typeof(ShapeResource))]
     [RoutePrefix("api")]
     public class ShapeController : ApiController
     {
         [HttpGet]
         [Route("shapes")]
         [AllowsQuery]
+        [ReturnsResource(typeof(ShapeResource))]
         public IEnumerable<Shape> GetAllShapes()
         {
             return new Shape[]
@@ -28,9 +28,26 @@ namespace Tests.Controllers
         
         [HttpGet]
         [Route("shape/{id}")]
+        [ReturnsResource(typeof(ShapeResource))]
         public Shape GetShape(string id)
         {
             return GetAllShapes().FirstOrDefault(s => s.Id == id);
+        }
+
+        [HttpGet]
+        [Route("groups")]
+        [AllowsQuery]
+        [DisableDefaultIncluded]
+        [ReturnsResource(typeof(GroupResource))]
+        public IEnumerable<Group> GetGroup()
+        {
+            return new[]
+            {
+                new Group(true, "1")
+                {
+                    Shapes = GetAllShapes().ToList()
+                }
+            };
         }
     }
 }

--- a/Tests/Models/Inheritance/Group.cs
+++ b/Tests/Models/Inheritance/Group.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace Tests.Models.Inheritance
+{
+    public class Group
+    {
+        public Group(bool prefill = false, string id = "123")
+        {
+            Id = id;
+            if (!prefill) return;
+
+            Name = $"Group {id}";
+        }
+        
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public List<Shape> Shapes { get; set; }
+    }
+}

--- a/Tests/Models/Inheritance/GroupResource.cs
+++ b/Tests/Models/Inheritance/GroupResource.cs
@@ -1,0 +1,14 @@
+﻿using Saule;
+
+namespace Tests.Models.Inheritance
+{
+    public class GroupResource : ApiResource
+    {
+        public GroupResource()
+        {
+            WithId(nameof(Group.Id));
+            Attribute(nameof(Group.Name));
+            HasMany<ShapeResource>(nameof(Group.Shapes));
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -141,6 +141,8 @@
     <Compile Include="Helpers\Paths.cs" />
     <Compile Include="Models\Inheritance\Circle.cs" />
     <Compile Include="Models\Inheritance\CircleResource.cs" />
+    <Compile Include="Models\Inheritance\Group.cs" />
+    <Compile Include="Models\Inheritance\GroupResource.cs" />
     <Compile Include="Models\Inheritance\Rectangle.cs" />
     <Compile Include="Models\Inheritance\RectangleResource.cs" />
     <Compile Include="Models\Inheritance\Shape.cs" />


### PR DESCRIPTION
Hi Jouke, 

Looks like i missed one scenario related to relationship. without this change if we have a `Group` object that has `List<Shape> Shapes`, then it would return such response

```
{
    "data": [
        {
            "type": "group",
            "id": "1",
            "links": {
                "self": "http://localhost/api/groups/1/"
            },
            "attributes": {
                "name": "Group 1"
            },
            "relationships": {
                "shapes": {
                    "links": {
                        "self": "http://localhost/api/groups/1/relationships/shapes/",
                        "related": "http://localhost/api/groups/1/shapes/"
                    },
                    "data": [
                        {
                            "type": "shape",
                            "id": "1"
                        },
                        {
                            "type": "shape",
                            "id": "2"
                        },
                        {
                            "type": "shape",
                            "id": "3"
                        }
                    ]
                }
            }
        }
    ],
    "links": {
        "self": "http://localhost/api/groups"
    },
    "included": [
        {
            "type": "shape",
            "id": "1",
            "links": {
                "self": "http://localhost/api/shape/1/"
            },
            "attributes": {
                "color": "Purple"
            }
        },
        {
            "type": "shape",
            "id": "2",
            "links": {
                "self": "http://localhost/api/shape/2/"
            },
            "attributes": {
                "color": "Green"
            }
        },
        {
            "type": "shape",
            "id": "3",
            "links": {
                "self": "http://localhost/api/shape/3/"
            },
            "attributes": {
                "color": "Purple"
            }
        }
    ]
}
```

as it ignores that new `IApiResourceProvider` for that case. to handle it i added new method there
```
ApiResource ResolveRelationship(object dataObject, ApiResource relationship);
```
and now when code would serialize `data->relationship` section and `included` section, it will use it and pass `ApiResource` of the related resource itself. It happens here

https://github.com/joukevandermaas/saule/blob/c508f7bae2b73e0a32a29283d0c661a6a6eeefda/Saule/Serialization/ResourceGraph.cs#L128-L149

and we pass `r.RelatedResource` to recursive `Build` method and for these cases we will call that new method above and will pass that `r.RelatedResource` as second parameter for that method, so resolving can happen based on the relationship as it might depend on it. `Saule/Resources/DefaultApiResourceProvider.cs` would just return the same `r.RelatedResource` back but would allow to customize ApiResource based on the relationship


I also added two new unit tests (one that validates group.Shapes types) and another one that validates `included` section itself and types there.

After the change the output would be 
```
{
    "data": [
        {
            "type": "group",
            "id": "1",
            "links": {
                "self": "http://localhost/api/groups/1/"
            },
            "attributes": {
                "name": "Group 1"
            },
            "relationships": {
                "shapes": {
                    "links": {
                        "self": "http://localhost/api/groups/1/relationships/shapes/",
                        "related": "http://localhost/api/groups/1/shapes/"
                    },
                    "data": [
                        {
                            "type": "circle",
                            "id": "1"
                        },
                        {
                            "type": "rectangle",
                            "id": "2"
                        },
                        {
                            "type": "circle",
                            "id": "3"
                        }
                    ]
                }
            }
        }
    ],
    "links": {
        "self": "http://localhost/api/groups"
    },
    "included": [
        {
            "type": "circle",
            "id": "1",
            "links": {
                "self": "http://localhost/api/circles/1/"
            },
            "attributes": {
                "color": "Purple",
                "radius": 42
            }
        },
        {
            "type": "rectangle",
            "id": "2",
            "links": {
                "self": "http://localhost/api/rectangles/2/"
            },
            "attributes": {
                "color": "Green",
                "left": 10,
                "top": 10,
                "width": 100,
                "height": 100
            }
        },
        {
            "type": "circle",
            "id": "3",
            "links": {
                "self": "http://localhost/api/circles/3/"
            },
            "attributes": {
                "color": "Purple",
                "radius": 42
            }
        }
    ]
}
```