### PR TITLE
Set encoding to UTF8 without BOM

### DIFF
--- a/Saule/Http/JsonApiMediaTypeFormatter.cs
+++ b/Saule/Http/JsonApiMediaTypeFormatter.cs
@@ -155,7 +155,7 @@ namespace Saule.Http
 
         private async Task WriteJsonToStream(JToken json, Stream stream)
         {
-            using (var writer = new StreamWriter(stream, Encoding.UTF8, 2048, true))
+            using (var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), 2048, true))
             {
                 await writer.WriteAsync(json.ToString(Formatting.None, _config.JsonConverters.ToArray()));
             }


### PR DESCRIPTION
`Encoding.UTF8` will include a UTF8 BOM character, which is invalid according to the [JSON spec RFC7159, Section 8.1](https://tools.ietf.org/html/rfc7159#section-8.1).
This was causing issues with (in particular) JavaScript clients that call `JSON.parse` on the response.
`UTF8Encoding` allows us to specify whether to include the BOM character or not.